### PR TITLE
Change `String` to `&str` for efficiency 🗡️

### DIFF
--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v0.10.6';
+const CACHE_VERSION = 'v0.10.7';
 const CACHE_LIST = [
   '/commentary/book.js',
   '/commentary/elasticlunr.min.js',

--- a/rs/wasm/src/searcher.rs
+++ b/rs/wasm/src/searcher.rs
@@ -123,7 +123,7 @@ impl Teaser {
         highlight.join("")
     }
 
-    fn search_result_excerpt(&mut self, body: &str, terms: Vec<String>, count: usize) -> String {
+    fn search_result_excerpt(&mut self, body: &str, terms: Vec<&str>, count: usize) -> String {
         let mut idx = 0;
 
         for whole in body.to_lowercase().split(". ") {
@@ -157,13 +157,9 @@ impl Teaser {
     }
 }
 
-fn uri_parser(link_uri: &str) -> (&str, String) {
+fn uri_parser(link_uri: &str) -> (&str, &str) {
     let uri: Vec<&str> = link_uri.split('#').collect();
-    let head = if uri.len() > 1 {
-        format!("#{}", uri[1])
-    } else {
-        "".to_owned()
-    };
+    let head = if uri.len() > 1 { uri[1] } else { "" };
 
     (uri[0], head)
 }
@@ -183,11 +179,11 @@ pub fn format_result(
         r#"<a href="{path_to_root}{page}?highlight={}{head}">{doc_breadcrumbs}</a><span class="teaser" aria-label="Search Result Teaser">{}</span>"#,
         js_sys::encode_uri_component(&term.split(' ').collect::<Vec<&str>>().join("%20"))
             .as_string()
-            .unwrap()
+            .unwrap_or_default()
             .replace('\'', "%27"),
         Teaser::new().search_result_excerpt(
             doc_body,
-            term.split(' ').map(|s| s.to_string()).collect(),
+            term.split(' ').collect::<Vec<&str>>(),
             count,
         )
     )

--- a/rs/wasm/src/searcher.rs
+++ b/rs/wasm/src/searcher.rs
@@ -157,22 +157,27 @@ impl Teaser {
     }
 }
 
-#[wasm_bindgen]
-pub fn format_result(
-    path_to_root: String,
-    link_uri: String,
-    doc_body: String,
-    doc_breadcrumbs: String,
-    term: String,
-    count: usize,
-) -> String {
+fn uri_parser(link_uri: &str) -> (&str, String) {
     let uri: Vec<&str> = link_uri.split('#').collect();
-    let page = uri[0];
     let head = if uri.len() > 1 {
         format!("#{}", uri[1])
     } else {
         "".to_owned()
     };
+
+    (uri[0], head)
+}
+
+#[wasm_bindgen]
+pub fn format_result(
+    path_to_root: &str,
+    link_uri: &str,
+    doc_body: &str,
+    doc_breadcrumbs: &str,
+    term: &str,
+    count: usize,
+) -> String {
+    let (page, head) = uri_parser(link_uri);
 
     format!(
         r#"<a href="{path_to_root}{page}?highlight={}{head}">{doc_breadcrumbs}</a><span class="teaser" aria-label="Search Result Teaser">{}</span>"#,
@@ -181,7 +186,7 @@ pub fn format_result(
             .unwrap()
             .replace('\'', "%27"),
         Teaser::new().search_result_excerpt(
-            &doc_body,
+            doc_body,
             term.split(' ').map(|s| s.to_string()).collect(),
             count,
         )


### PR DESCRIPTION
* Change the value received from `js` from `String` to `&str` to improve efficiency.
* In addition, the process related to URI was cut out into a function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the search functionality to improve performance and accuracy.
  - Enhanced the result formatting for better clarity in search results.

- **Chores**
  - Updated the service worker version for improved caching and offline support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->