### PR TITLE
Create and add `<li>`elements with wasm 🧝🏻‍♀️

### DIFF
--- a/js/searcher.js
+++ b/js/searcher.js
@@ -1,7 +1,7 @@
 import markjs from 'mark.js';
 import { Fzf, extendedMatch } from 'fzf';
 
-import wasmInit, { format_result } from './wasm_book.js';
+import wasmInit, { create_search_results_list } from './wasm_book.js';
 
 const searchMain = () => {
   const ELEM_BAR = document.getElementById('searchbar');
@@ -27,7 +27,7 @@ const searchMain = () => {
     const count = Math.min(results.length, searchConfig.results_options.limit_results);
 
     ELEM_HEADER.innerText = (results.length > count ? 'Over ' : '') + `${count} search results for: ${term}`;
-    return results.slice(0, count);
+    return results.slice(count);
   };
 
   // Eventhandler for keyevents while the searchbar is focused
@@ -42,9 +42,7 @@ const searchMain = () => {
     ELEM_RESULTS.innerHTML = '';
 
     for (const result of getResults(term)) {
-      const resultElem = document.createElement('li');
-
-      resultElem.innerHTML = format_result(
+      create_search_results_list(
         PATH_TO_ROOT,
         searchConfig.doc_urls[result.ref],
         result.doc.body,
@@ -52,8 +50,6 @@ const searchMain = () => {
         term,
         searchConfig.results_options.teaser_word_count,
       );
-
-      ELEM_RESULTS.appendChild(resultElem);
     }
 
     resultMarker.mark(decodeURIComponent(term).split(' '), {

--- a/rs/wasm/src/searcher.rs
+++ b/rs/wasm/src/searcher.rs
@@ -165,17 +165,21 @@ fn uri_parser(link_uri: &str) -> (&str, &str) {
 }
 
 #[wasm_bindgen]
-pub fn format_result(
+pub fn create_search_results_list(
     path_to_root: &str,
     link_uri: &str,
     doc_body: &str,
     doc_breadcrumbs: &str,
     term: &str,
     count: usize,
-) -> String {
+) {
+    let window = web_sys::window().unwrap();
+    let document = window.document().unwrap();
+
     let (page, head) = uri_parser(link_uri);
 
-    format!(
+    let new_element = document.create_element("li").unwrap();
+    new_element.set_inner_html(&format!(
         r#"<a href="{path_to_root}{page}?highlight={}#{head}">{doc_breadcrumbs}</a><span class="teaser" aria-label="Search Result Teaser">{}</span>"#,
         js_sys::encode_uri_component(&term.split(' ').collect::<Vec<&str>>().join("%20"))
             .as_string()
@@ -186,5 +190,12 @@ pub fn format_result(
             term.split(' ').collect::<Vec<&str>>(),
             count,
         )
-    )
+    ));
+
+    let parent = document
+        .get_element_by_id("searchresults")
+        .ok_or(JsValue::NULL)
+        .unwrap();
+
+    parent.append_child(&new_element).unwrap();
 }


### PR DESCRIPTION
Previously, `<li>`elements were created and added on the `js` side, but this was changed to be done on the `wasm` side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced search results display with a new list creation method.

- **Refactor**
  - Renamed and repurposed the search result formatting function for direct DOM manipulation.

- **Style**
  - Adjusted search results presentation through DOM element creation and manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->