### PR TITLE
Assign an id to `<main>` /  also, redefine the roles of `ToC` and `Sitemap` clearly 🦘

### DIFF
--- a/js/book.js
+++ b/js/book.js
@@ -16,13 +16,13 @@ const chapterNavigation = () => {
       }
 
       if (e.key === 'ArrowRight') {
-        const nextButton = document.querySelector('.content main .nav-chapters.next');
+        const nextButton = document.getElementById('main').querySelector('.nav-chapters.next');
 
         if (nextButton) {
           globalThis.location.href = nextButton.href;
         }
       } else if (e.key === 'ArrowLeft') {
-        const previousButton = document.querySelector('.content main .nav-chapters.previous');
+        const previousButton = document.getElementById('main').querySelector('.nav-chapters.previous');
 
         if (previousButton) {
           globalThis.location.href = previousButton.href;

--- a/js/book.js
+++ b/js/book.js
@@ -33,9 +33,13 @@ const chapterNavigation = () => {
   );
 };
 
-wasmInit().then(() => {
-  attribute_external_links();
-});
+wasmInit()
+  .then(() => {
+    attribute_external_links();
+  })
+  .catch(error => {
+    console.error('Error Attribute external links: ', error);
+  });
 
 document.addEventListener(
   'DOMContentLoaded',

--- a/js/codeblock.js
+++ b/js/codeblock.js
@@ -20,6 +20,18 @@ const codeCopy = trigger => {
 };
 
 export const codeBlock = () => {
+  const main = document.getElementById('main');
+
+  if (main === null) {
+    return;
+  }
+
+  const codeQuery = main.querySelectorAll('pre code');
+
+  if (codeQuery.length <= 0) {
+    return;
+  }
+
   // capture hover event in iOS
   if (globalThis.ontouchstart !== undefined) {
     document.addEventListener('touchstart', () => {}, { once: false, passive: true });
@@ -31,7 +43,7 @@ export const codeBlock = () => {
   clip.setAttribute('aria-label', 'Copy to clipboard');
   clip.innerHTML = '<i class="tooltiptext"></i>';
 
-  for (const code of document.getElementById('main').querySelectorAll('pre code')) {
+  for (const code of codeQuery) {
     if (code.classList.contains('language-txt')) {
       continue;
     }

--- a/js/codeblock.js
+++ b/js/codeblock.js
@@ -31,7 +31,7 @@ export const codeBlock = () => {
   clip.setAttribute('aria-label', 'Copy to clipboard');
   clip.innerHTML = '<i class="tooltiptext"></i>';
 
-  for (const code of document.querySelector('.content main').querySelectorAll('pre code')) {
+  for (const code of document.getElementById('main').querySelectorAll('pre code')) {
     if (code.classList.contains('language-txt')) {
       continue;
     }

--- a/js/searcher.js
+++ b/js/searcher.js
@@ -80,7 +80,7 @@ const searchMain = () => {
     const term = decodeURIComponent(param);
     ELEM_BAR.value = term;
 
-    const marker = new markjs(document.querySelector('.content main'));
+    const marker = new markjs(document.getElementById('main'));
     marker.mark(term.split(' '), {
       accuracy: 'complementary',
     });

--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v0.11.3';
+const CACHE_VERSION = 'v0.12.0';
 const CACHE_LIST = [
   '/commentary/book.js',
   '/commentary/elasticlunr.min.js',

--- a/js/table-of-contents.js
+++ b/js/table-of-contents.js
@@ -16,12 +16,13 @@ export default class TableOfContents {
       },
       {
         root: document.getElementById('content main'),
+        threshold: 1.0,
       },
     );
 
     this.#pagetoc = document.getElementsByClassName('pagetoc')[0];
 
-    for (const el of document.querySelectorAll('.content a.header')) {
+    for (const el of document.getElementById('main').querySelectorAll('a.header')) {
       this.#observer.observe(el);
 
       const link = document.createElement('a');

--- a/rs/wasm/src/book.rs
+++ b/rs/wasm/src/book.rs
@@ -13,7 +13,7 @@ pub fn attribute_external_links() {
 
     let elements = document
         .get_element_by_id("main")
-        .unwrap()
+        .expect("id 'main' not found")
         .query_selector_all(r#"a[href^="http"]"#)
         .unwrap();
 

--- a/rs/wasm/src/book.rs
+++ b/rs/wasm/src/book.rs
@@ -12,7 +12,9 @@ pub fn attribute_external_links() {
     let document = window.document().unwrap();
 
     let elements = document
-        .query_selector_all(r#".content main a[href^="http"]"#)
+        .get_element_by_id("main")
+        .unwrap()
+        .query_selector_all(r#"a[href^="http"]"#)
         .unwrap();
 
     for el in node_list_to_array(elements).iter() {
@@ -22,4 +24,3 @@ pub fn attribute_external_links() {
         }
     }
 }
-

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -91,7 +91,7 @@
     </div>
 
     <div id="page" class="page">
-      <div id="sidebar" class="sidebar" aria-label="Table of contents">
+      <div id="sidebar" class="sidebar" aria-label="Site map">
         <nav id="side-scroll" class="sidebar-scrollbox">
           {{#toc}}{{/toc}}
         </nav>
@@ -100,7 +100,7 @@
       <div id="content" class="content">
         <spacer></spacer>
 
-        <main>
+        <main id="main">
           {{{ content }}}
 
           <nav class="nav-wrapper" aria-label="Page navigation">
@@ -120,7 +120,7 @@
 
         <spacer></spacer>
 
-        <div class="righttoc">
+        <div class="righttoc" aria-label="Table of contents">
           <nav class="pagetoc"></nav>
         </div>
       </div>


### PR DESCRIPTION
I originally started to resolve #63, but as a result, the question was never resolved regarding the `root` designation of the `IntersectionObserver` used in ToC.

1. However, we will do this because we believe that by assigning an `id` to the `<main>` in the process,
We can make the process more efficient than before.

2. Also, what was previously defined as `Table of contents` will now appear externally as `Site map`,
And what was internally called `pagetoc` will be redefined externally as `Table of contents`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Enhanced element retrieval for navigation, code blocks, and external link attribution, resulting in improved performance.

- **Bug Fixes**
  - Added error handling to the initialization process to ensure stability.

- **Refactor**
  - Streamlined element selection by using more specific and efficient methods.

- **Documentation**
  - Updated `aria-label` for better accessibility and clarity.

- **Chores**
  - Incremented cache version to reflect new updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->