### PR TITLE
Corresponding to #65 and #66 🏛️

### DIFF
--- a/js/biome.json
+++ b/js/biome.json
@@ -11,7 +11,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "correctness": {
+        "noConstructorReturn": "off"
+      }
     }
   },
   "javascript": {

--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v0.12.1';
+const CACHE_VERSION = 'v0.12.2';
 const CACHE_LIST = [
   '/commentary/book.js',
   '/commentary/elasticlunr.min.js',


### PR DESCRIPTION
Main topic is "The codeBlock function does not handle the scenario where all workers are busy"from https://github.com/CoralPink/commentary/pull/66#discussion_r1412817809.

The following changes were also made.
* Fixed an issue where the number of threads generated was not being managed correctly.
* Organize `WorkerPool`s as classes.
* Operate workerPool as a singleton (Suppress `biome`'s `noConstructorReturn` warning accordingly).