### PR TITLE
Convert and save the url table so that it can be easily handled by rust 🏉

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -87,6 +87,7 @@ jobs:
           rm book/tomorrow-night.css
           rm book/css/variables.css
           rm book/mark.min.js
+          rm -rf book/searchindex.js
           rm -rf book/FontAwesome
 
       - name: Generate The Sitemap

--- a/debug.sh
+++ b/debug.sh
@@ -36,6 +36,7 @@ mdbook build --dest-dir commentary
 #rm commentary/tomorrow-night.css
 #rm commentary/css/variables.css
 #rm commentary/mark.min.js
+#rm -rf commentary/searchindex.js
 #rm -rf commentary/FontAwesome
 
 echo '\n🐥 complete!'

--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v0.12.2';
+const CACHE_VERSION = 'v0.12.3';
 const CACHE_LIST = [
   '/commentary/book.js',
   '/commentary/elasticlunr.min.js',

--- a/rs/wasm/src/searcher.rs
+++ b/rs/wasm/src/searcher.rs
@@ -219,7 +219,14 @@ impl SearchResult {
         doc_breadcrumbs: &str,
         term: &str,
     ) {
-        let (page, head) = uri_parser(&self.url_table[reference.parse::<usize>().expect("failed: result.ref")]);
+        let idx = match reference.parse::<usize>() {
+            Ok(n) => n,
+            Err(_) => {
+                console_log!("Error: Invalid result.ref: {reference}");
+                return;
+            }
+        };
+        let (page, head) = uri_parser(&self.url_table[idx]);
         let terms = term.split_whitespace().collect::<Vec<&str>>();
 
         let new_element = self

--- a/rs/wasm/src/searcher.rs
+++ b/rs/wasm/src/searcher.rs
@@ -1,3 +1,4 @@
+use js_sys::Array;
 use rust_stemmers::{Algorithm, Stemmer};
 use wasm_bindgen::prelude::*;
 use web_sys::{Document, Element};
@@ -177,12 +178,17 @@ pub struct SearchResult {
     parent: Element,
     count: usize,
     teaser: Teaser,
+    url_table: Vec<String>,
 }
 
 #[wasm_bindgen]
 impl SearchResult {
     #[wasm_bindgen(constructor)]
-    pub fn new(path_to_root: String, count: usize) -> Result<SearchResult, JsValue> {
+    pub fn new(
+        path_to_root: String,
+        count: usize,
+        doc_urls: Array,
+    ) -> Result<SearchResult, JsValue> {
         let window = web_sys::window().ok_or("No global `window` exists")?;
         let document = window
             .document()
@@ -191,23 +197,29 @@ impl SearchResult {
             .get_element_by_id("searchresults")
             .ok_or("No element with ID `searchresults`")?;
 
+        let url_table: Vec<String> = doc_urls
+            .iter()
+            .filter_map(|value| value.as_string())
+            .collect();
+
         Ok(SearchResult {
             path_to_root,
             document,
             parent,
             count,
             teaser: Teaser::new(),
+            url_table,
         })
     }
 
     pub fn append_search_result(
         &mut self,
-        link_uri: &str,
+        reference: &str,
         doc_body: &str,
         doc_breadcrumbs: &str,
         term: &str,
     ) {
-        let (page, head) = uri_parser(link_uri);
+        let (page, head) = uri_parser(&self.url_table[reference.parse::<usize>().expect("failed: result.ref")]);
         let terms = term.split_whitespace().collect::<Vec<&str>>();
 
         let new_element = self


### PR DESCRIPTION
Keep the data in `searchindex.json` at each required location.

Resources are being used more efficiently than before, but the process during initialization has increased.
As far as I tested locally, the difference was about 0.001s.

I'm a little worried about it, but since it's working so well, I think I'll merge it.

Also, proceed as if `searchindex.js` is no longer used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced search functionality with improved result handling and user interface updates.

- **Bug Fixes**
  - Fixed issues with search result display and error handling during search operations.

- **Refactor**
  - Streamlined search-related code for better performance and maintainability.

- **Chores**
  - Updated service worker cache version to ensure users receive the latest content updates.

- **Documentation**
  - No visible changes to end-user documentation in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->