### PR TITLE
Controls the immediate activation of the `serviceworker` 🧜‍♀️

### DIFF
--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,6 +1,4 @@
 const CACHE_VERSION = 'v0.13.0';
-const ENABLE_SKIP_WAITING = true;
-
 const CACHE_LIST = [
   '/commentary/book.js',
   '/commentary/elasticlunr.min.js',


### PR DESCRIPTION
#69, as posted.

Use `skipWaiting()` on `major`/`minor` version updates to immediately enable the latest ServiceWorker.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved service worker caching strategy with a new versioning system.
- **Refactor**
  - Enhanced service worker install event with better version management functions.
- **Chores**
  - Updated cache version constant to 'v0.13.0' for better resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->