### PR TITLE
Fix typo

### DIFF
--- a/src/neovim/au/nvim_create_autocmd.md
+++ b/src/neovim/au/nvim_create_autocmd.md
@@ -9,10 +9,10 @@ nvim_create_autocmd({event}, {*opts}) nvim_create_autocmd()
 
   The API allows for two (mutually exclusive) types of actions to be
   executed when the autocommand triggers: a callback function (Lua or
-  Vimscript), or a command (like regular autocommands).
+  Vim script), or a command (like regular autocommands).
 
   このAPIでは、オートコマンドのトリガー時に実行されるアクションとして、
-  コールバック関数（LuaまたはVimscript）、
+  コールバック関数（LuaまたはVim script）、
   またはコマンド（通常のオートコマンドと同様）の
   2種類（相互に排他的）を指定することができる。
 ```

--- a/src/neovim/function/vim-cmd.md
+++ b/src/neovim/function/vim-cmd.md
@@ -134,7 +134,7 @@ vim.keymap.set('n', '<Leader>9', function() vim.cmd.colo 'blue' end)
 この先でも、しれっとこんな記述をしていくので、よろしくどうぞ😆
 
 ```admonish success
-`vim.cmd`については、VimScriptのコマンドをコードから呼び出せるよー❗っていうことが理解できればOKです。
+`vim.cmd`については、Vim scriptのコマンドをコードから呼び出せるよー❗っていうことが理解できればOKです。
 
 ここまでくると、結構いろいろなことがコードから実行できるって分かるので、楽しくなってきますね😆
 ```

--- a/src/neovim/keybind.md
+++ b/src/neovim/keybind.md
@@ -247,7 +247,7 @@ t[nore]map     |  -   |  -  |  -  |  -  |  -  |  -  | yes  |  -   |
 l[nore]map     |  -   | yes | yes |  -  |  -  |  -  |  -   | yes  |
 ```
 
-`Vimscript`準拠の表記になっていますが、先頭文字がそれぞれ`vim.keymap.set`の`{mode}`に対応しています。
+`Vim script`準拠の表記になっていますが、先頭文字がそれぞれ`vim.keymap.set`の`{mode}`に対応しています。
 ~~~
 
 冒頭の例で言うと、`'i'`はインサートモードを指しています。

--- a/src/neovim/leader.md
+++ b/src/neovim/leader.md
@@ -73,7 +73,7 @@ g:mapleader "が設定されていない場合や空の場合は、代わりに�
 ```
 ~~~
 
-VimScriptの書き方だと思われますが、`g:`というのが`global`で、`mapleader`が変数名ですね 🤔
+Vim scriptの書き方だと思われますが、`g:`というのが`global`で、`mapleader`が変数名ですね 🤔
 
 これはなんかもう`nvim_set_var`が強すぎるので楽勝です❤️
 

--- a/src/neovim/lsp/copilot.md
+++ b/src/neovim/lsp/copilot.md
@@ -44,7 +44,7 @@ Coca-Cola{{footnote: Abbey Road 収録の Come Together の詩に登場するこ
 ...ありますが、わたしは`copilot.lua`にしました👩‍✈️
 
 ```admonish note
-`copilot.vim`が`Vimscript`で書かれているのに対して、`lua`で書かれているのが`copilot.lua`です。
+`copilot.vim`が`Vim script`で書かれているのに対して、`lua`で書かれているのが`copilot.lua`です。
 ```
 
 だってほら、こっちの方が親和性高そう💕

--- a/src/neovim/user-config.md
+++ b/src/neovim/user-config.md
@@ -4,21 +4,21 @@
 
 ```admonish info title="[Load user config](https://neovim.io/doc/user/starting.html#config)"
 A file containing initialization commands is generically called a "vimrc" or config file.
-It can be either Vimscript ("init.vim") or Lua ("init.lua"), but not both. 
+It can be either Vim script ("init.vim") or Lua ("init.lua"), but not both. 
 
 初期化コマンドを含むファイルは一般に "vimrc" または config ファイルと呼ばれます。
-Vimscript ("init.vim")またはLua ("init.lua")のどちらかになりますが、両方は使えません。
+Vim script ("init.vim")またはLua ("init.lua")のどちらかになりますが、両方は使えません。
 ```
 
-なんということでしょう❗`Vimscript`または`Lua`のどちらかを選ばなければなりません😩
+なんということでしょう❗`Vim script`または`Lua`のどちらかを選ばなければなりません😩
 
 ...なんつって。白々しかったですよね〜😉
 
 このサイトでは、`WezTerm`でも散々扱ってきた`Lua`を選択します。
-(というか、わたしは`VimScript`を扱えません...😅)
+(というか、わたしは`Vim script`を扱えません...😅)
 
 ```admonish note
-`Neovim`は`Vimscript`を扱えますが、後継の`Vim9 script`はサポートしないことが表明されているようです。
+`Neovim`は`Vim script`を扱えますが、後継の`Vim9 script`はサポートしないことが表明されているようです。
 
 もしこれを扱いたい場合は [Vim](https://www.vim.org) を使う必要があります。
 
@@ -28,7 +28,7 @@ Vimscript ("init.vim")またはLua ("init.lua")のどちらかになりますが
 ```admonish warning
 あと、これは結構強調しておきたいんですが、
 
-「`Vimscript`ではああでしたが、`lua`ではこうでして❗」みたいな "移行" を目的とした書き方はしません。
+「`Vim script`ではああでしたが、`lua`ではこうでして❗」みたいな "移行" を目的とした書き方はしません。
 ```
 
 わたし自身は `Neovim` → `WezTerm` という順番で`Lua`に触れてきましたが、難易度的には`Neovim`の方が高いと思ってます。


### PR DESCRIPTION
Thanks, I enjoyed reading it.

I found a typo and will correct it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the term "Vimscript" to "Vim script" across various documentation files for consistency.
  - Adjusted capitalization of "Lua" and other terms as needed for clarity.
  - Ensured language consistency in admonish blocks and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->