### PR TITLE
`Worker.terminate()` into the process 🎱

### DIFF
--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v0.18.2';
+const CACHE_VERSION = 'v0.18.3';
 const CACHE_LIST = [
   '/commentary/book.js',
   '/commentary/hl-worker.js',


### PR DESCRIPTION
The `Worker` are released when the user navigates to the page in the browser, so there were no explicit instructions from me.

However, if a user has been working on one page for a long time, it is not a good feeling to have unused workers remaining forever, and I, for one, would like to take such users seriously 😉

So I decided to release the `Worker` explicitly!


...In addition, the time until timeout was re-set to a shorter period.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automatic timeout for idle workers to improve resource management.
- **Refactor**
	- Enhanced worker pool management with a new release mechanism.
- **Chores**
	- Updated service worker cache version for better performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->