### PR TITLE
You only need to call `wasm` once when searching 🛎️

### DIFF
--- a/js/book.js
+++ b/js/book.js
@@ -40,12 +40,8 @@ const searchHandler = () => {
     ELEM_HEADER.innerText = 'No search result.';
     return;
   }
-
   ELEM_HEADER.innerText = `${results.length} search results for : ${term}`;
-
-  for (const result of results) {
-    searchResult.append_search_result(result.ref, result.doc.body, result.doc.breadcrumbs, term);
-  }
+  searchResult.append_search_result(results, term);
 
   resultMarker.mark(decodeURIComponent(term).split(' '), {
     accuracy: 'complementary',

--- a/js/finder.js
+++ b/js/finder.js
@@ -9,15 +9,15 @@ export default class Finder {
   search(term) {
     return this.#fzf
       .find(term)
-      .map(data => ({ doc: this.#storeDocs[data.item], ref: data.item, score: data.score }))
-      .filter(x => x.score >= LOWER_LIMIT_SCORE);
+      .map(x => ({ doc: this.#storeDocs[x.item], key: x.item, score: x.score }))
+      .filter(y => y.score >= LOWER_LIMIT_SCORE);
   }
 
   constructor(storeDocs, limit) {
     /** @see https://github.com/HillLiu/docker-mdbook */
     this.#fzf = new Fzf(Object.keys(storeDocs), {
       limit,
-      selector: item => `${storeDocs[item].breadcrumbs}${storeDocs[item].body}`,
+      selector: x => `${storeDocs[x].title} ${storeDocs[x].body}`,
       tiebreakers: [byStartAsc],
     });
 

--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v0.19.0';
+const CACHE_VERSION = 'v0.19.1';
 
 const CACHE_URL = '/commentary/';
 const CACHE_LIST = [

--- a/rs/wasm/Cargo.lock
+++ b/rs/wasm/Cargo.lock
@@ -73,6 +73,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b713f70513ae1f8d92665bbbbda5c295c2cf1da5542881ae5eefe20c9af132"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,10 +167,13 @@ checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasm-book"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "js-sys",
  "rust-stemmers",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_derive",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/rs/wasm/Cargo.toml
+++ b/rs/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-book"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["CoralPink <teqt6ytqt@mozmail.com>"]
 edition = "2021"
 rust-version = "1.71"
@@ -20,6 +20,9 @@ strip = "symbols"
 [dependencies]
 js-sys = "0.3"
 rust-stemmers = "1.2"
+serde = "1.0"
+serde_derive = "1.0"
+serde-wasm-bindgen = "0.6"
 wasm-bindgen = "0.2"
 
 [dependencies.web-sys]

--- a/rs/wasm/src/lib.rs
+++ b/rs/wasm/src/lib.rs
@@ -1,2 +1,5 @@
+#[macro_use]
+extern crate serde_derive;
+
 pub mod book;
 pub mod searcher;

--- a/rs/wasm/src/searcher/mod.rs
+++ b/rs/wasm/src/searcher/mod.rs
@@ -29,19 +29,19 @@ fn parse_uri(link_uri: &str) -> (&str, &str) {
     (uri[0], head)
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Deserialize)]
 pub struct DocObject {
     body: String,
     breadcrumbs: String,
-    id: String,
-    title: String,
+    //id: String,
+    //title: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Deserialize)]
 pub struct ResultObject {
     doc: DocObject,
     key: String,
-    score: u32,
+    //score: u32,
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
I think I can finally solve #57 !

I took it seriously and it was surprisingly easy 😆
(It just didn't work before because I had misjudged the configuration of the parameters...)

Previously, it required the same number of `wasm` calls as the number of search hits.
But with this change, only `one call` is needed!

Also, we have removed `breadcrumbs` from the search target and changed it to use `title`.
So the search results may change a bit again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the app's search functionality for better performance and user experience.
- **Refactor**
	- Streamlined the search result display mechanism.
	- Updated variable names and logic in the search filtering and mapping process for clarity and efficiency.
- **Chores**
	- Updated the service worker cache version for improved app caching.
- **Dependencies**
	- Added new external dependency for serialization purposes in the WebAssembly module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->