### PR TITLE
try: Should I install `wasm-bindgen-cli`? 🏉

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           cargo install mdbook-admonish
           cargo install mdbook-tailor
+          cargo install wasm-bindgen-cli
           cargo install wasm-pack
           cargo install --path ./rs/mdbook-footnote
 


### PR DESCRIPTION
Could installing `wasm-bindgen-cli` reduce build time?

Give it a try!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow to include the installation of `wasm-bindgen-cli` for dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->