### PR TITLE
Lighten the weight of the search term highlighting process 🪶

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -26,15 +26,8 @@ runnable = false
 enable = false
 
 [output.html.search]
-enable = true            # enables the search feature
 limit-results = 100      # maximum number of search results
 teaser-word-count = 20   # number of words used for a search result teaser
-use-boolean-and = true   # multiple search terms must all match
-boost-title = 2          # ranking boost factor for matches in headers
-boost-hierarchy = 1      # ranking boost factor for matches in page names
-boost-paragraph = 1      # ranking boost factor for matches in text
-expand = true            # partial words will match longer terms
-heading-split-level = 6  # link results to heading levels
 copy-js = true           # (apparently, searchindex.json will not be created unless this is enabled.)
 
 [preprocessor.admonish]
@@ -45,3 +38,16 @@ after = ["links"]
 [preprocessor.footnote]
 
 [preprocessor.tailor]
+
+
+# The following parameter settings are not available for this site.
+# It is not known if it will be possible to enable these settings in the future.
+
+#[output.html.search]
+#enable = true            # enables the search feature
+#use-boolean-and = true   # multiple search terms must all match
+#boost-title = 2          # ranking boost factor for matches in headers
+#boost-hierarchy = 1      # ranking boost factor for matches in page names
+#boost-paragraph = 1      # ranking boost factor for matches in text
+#expand = true            # partial words will match longer terms
+#heading-split-level = 6  # link results to heading levels

--- a/js/book.js
+++ b/js/book.js
@@ -15,8 +15,6 @@ const ELEM_ICON = document.getElementById('search-toggle');
 const ELEM_HEADER = document.getElementById('searchresults-header');
 const ELEM_OUTER = document.getElementById('searchresults-outer');
 
-const resultMarker = new Mark(ELEM_RESULTS);
-
 let searchResult;
 let finder;
 
@@ -49,11 +47,6 @@ const searchHandler = () => {
   }
   ELEM_HEADER.innerText = `${results.length} search results for : ${term}`;
   searchResult.append_search_result(results, term);
-
-  resultMarker.mark(decodeURIComponent(term).split(' '), {
-    accuracy: 'complementary',
-    exclude: ['a'],
-  });
 
   ELEM_OUTER.classList.remove('hidden');
 };

--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v0.22.0';
+const CACHE_VERSION = 'v0.23.0';
 
 const CACHE_URL = '/commentary/';
 const CACHE_LIST = [

--- a/rs/wasm/Cargo.lock
+++ b/rs/wasm/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "bumpalo"
-version = "3.15.2"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b1be7772ee4501dba05acbe66bb1e8760f6a6c474a36035631638e4415f130"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "cfg-if"
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b713f70513ae1f8d92665bbbbda5c295c2cf1da5542881ae5eefe20c9af132"
+checksum = "4c1432112bce8b966497ac46519535189a3250a3812cd27a999678a69756f79f"
 dependencies = [
  "js-sys",
  "serde",

--- a/rs/wasm/Cargo.lock
+++ b/rs/wasm/Cargo.lock
@@ -54,16 +54,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-stemmers"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,10 +157,9 @@ checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasm-book"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "js-sys",
- "rust-stemmers",
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",

--- a/rs/wasm/Cargo.toml
+++ b/rs/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-book"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["CoralPink <teqt6ytqt@mozmail.com>"]
 edition = "2021"
 rust-version = "1.74"
@@ -19,7 +19,6 @@ strip = "symbols"
 
 [dependencies]
 js-sys = "0.3"
-rust-stemmers = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 wasm-bindgen = "0.2"

--- a/rs/wasm/src/searcher/teaser.rs
+++ b/rs/wasm/src/searcher/teaser.rs
@@ -83,9 +83,9 @@ impl Teaser {
             if word.1 != TERM_WEIGHT {
                 highlight.push(&body[word.2..index + word.0.len()]);
             } else {
-                highlight.push("<em>");
+                highlight.push("<mark>");
                 highlight.push(&body[word.2..index + word.0.len()]);
-                highlight.push("</em>");
+                highlight.push("</mark>");
             }
 
             index = word.2 + word.0.len();

--- a/rs/wasm/src/searcher/teaser.rs
+++ b/rs/wasm/src/searcher/teaser.rs
@@ -1,5 +1,3 @@
-use rust_stemmers::{Algorithm, Stemmer};
-
 const TERM_WEIGHT: u32 = 40;
 
 pub struct Teaser {
@@ -105,13 +103,8 @@ impl Teaser {
 
             for separate in words {
                 if !separate.is_empty() {
-                    let stemmed = Stemmer::create(Algorithm::English).stem(separate);
-
-                    for term in terms
-                        .iter()
-                        .map(|w| Stemmer::create(Algorithm::English).stem(w))
-                    {
-                        if stemmed.starts_with(&term.to_lowercase()) {
+                    for term in terms.iter() {
+                        if separate.to_lowercase().contains(&term.to_lowercase()) {
                             value = TERM_WEIGHT;
                             self.found = true;
                         }

--- a/scss/_chrome.scss
+++ b/scss/_chrome.scss
@@ -1,8 +1,8 @@
 @use 'variables' as var;
 
 mark {
-  color: var(--fg);
   background: linear-gradient(rgba(0, 0, 0, 0) 70%, var(--search-mark-bg));
+  font-weight: bold;
 }
 
 .content {
@@ -365,11 +365,6 @@ table {
         clear: both;
         margin: 0.4rem 0 0 1.25rem;
         font-size: 0.8em;
-
-        em {
-          background: linear-gradient(rgba(0, 0, 0, 0) 80%, var(--search-mark-bg));
-          font-weight: bold;
-        }
       }
     }
   }


### PR DESCRIPTION
This time, we mainly worked on the search highlighting process.

There are two main changes.

- I stopped using `rust-stemmers`, which is almost meaningless for Japanese sites.
(I was using it even though it was not Japanese compatible in the first place.)
This change may have caused some differences in the highlighted areas from before, but I think it is acceptable.

- There was no need to use `mark.js` for highlighting within the search dialog.
Since this can be done, it would seem possible to eliminate the dependency on `mark.js` altogether, but since this would require several more steps, we will not do so at this time.

Other changes include a slightly different look for search highlights.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the visual presentation of search results by changing highlight tags from `<em>` to `<mark>` and making the highlighted text bold for better visibility.
- **Bug Fixes**
	- Simplified the logic for stemming in search results to improve accuracy.
- **Style**
	- Adjusted styles to align with the new highlighting feature and removed unnecessary color styling for a cleaner look.
- **Chores**
	- Updated the service worker cache version to ensure users receive the latest app updates efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->