### PR TITLE
Reduce the amount of data passed from `js` to `wasm` when searching 🛳️

### DIFF
--- a/js/finder.js
+++ b/js/finder.js
@@ -4,24 +4,32 @@ const LOWER_LIMIT_SCORE = 56;
 
 export default class Finder {
   #fzf;
-  #storeDocs;
+
+  #docs = {};
+  #titles = [];
 
   constructor(storeDocs, limit) {
-    this.#storeDocs = storeDocs;
+    for (const key of Object.keys(storeDocs)) {
+      // The `id` is discarded and the `title` is retained separately.
+      const { id, title, ...rest } = storeDocs[key];
+
+      this.#titles.push(title);
+      this.#docs[key] = rest;
+    }
 
     /** @see https://github.com/HillLiu/docker-mdbook */
-    this.#fzf = new Fzf(Object.keys(storeDocs), {
+    this.#fzf = new Fzf(Object.keys(this.#docs), {
       limit,
-      selector: x => `${this.#storeDocs[x].title} ${this.#storeDocs[x].body}`,
+      selector: x => `${this.#titles[x]} ${this.#docs[x].body}`,
       tiebreakers: [byStartAsc],
     });
   }
 
   #filterSatisfactory(array) {
     if (array.length === 0 || array[0].score < LOWER_LIMIT_SCORE) {
-        // I am not sure if it is a spec or not, but sometimes fzf returns a negative score.
-        // I'm unwilling to do so, but I'll deal with it anyway using filters.
-        return array.filter(x => x.score >= 0);
+      // I am not sure if it is a spec or not, but sometimes fzf returns a negative score.
+      // I'm unwilling to do so, but I'll deal with it anyway using filters.
+      return array.filter(x => x.score >= 0);
     }
 
     let low = 1; // '0' is already checked, so start with '1'
@@ -45,7 +53,7 @@ export default class Finder {
 
   search(term) {
     return this.#filterSatisfactory(this.#fzf.find(term)).map(x => ({
-      doc: this.#storeDocs[x.item],
+      doc: this.#docs[x.item],
       key: x.item,
       score: x.score,
     }));

--- a/rs/wasm/src/searcher/mod.rs
+++ b/rs/wasm/src/searcher/mod.rs
@@ -45,8 +45,6 @@ fn scoring_notation(score: usize) -> String {
 pub struct DocObject {
     body: String,
     breadcrumbs: String,
-    //id: String,
-    //title: String,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Remove `id`, `title`, which were not used during search, to reduce the amount of data passed from `js` to `wasm`
This should improve the efficiency of the search process 😁

The initialisation process appears to have increased, but as long as it has been tested in the local environment, it does not appear to affect performance that much. (In fact, it seems to be getting faster...?🤔)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the internal document storage mechanism for enhanced search efficiency.
	- Streamlined the search functionality by adjusting how documents are accessed and filtered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->