### PR TITLE
Using the `Popover API` in `Theme Selector` 🍿

### DIFF
--- a/js/book.js
+++ b/js/book.js
@@ -2,7 +2,7 @@ import { procCodeBlock } from './codeblock.js';
 import { initGlobalSearch, initSearch } from './searcher.js';
 import { initSidebar } from './sidebar.js';
 import { initTableOfContents } from './table-of-contents.js';
-import { initThemeSelector } from './theme-selector.js';
+import { initTheme, initThemeSelector } from './theme-selector.js';
 
 import initWasm, { attribute_external_links } from './wasm_book.js';
 
@@ -26,8 +26,9 @@ const initialize = async () => {
 };
 
 (() => {
-  initGlobalSearch();
   initSidebar();
+  initTheme();
+  initGlobalSearch();
 
   document.addEventListener('DOMContentLoaded', initialize, { once: true, passive: true });
 })();

--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v1.0.0';
+const CACHE_VERSION = 'v1.1.0';
 
 const CACHE_URL = '/commentary/';
 const CACHE_LIST = [

--- a/js/theme-selector.js
+++ b/js/theme-selector.js
@@ -1,35 +1,11 @@
 import { writeLocalStorage } from './storage.js';
 
-const THEME_LIST = 'theme-list';
-const THEME_SELECTED = 'theme-selected';
-const THEME_TOGGLE = 'theme-toggle';
-
 const SAVE_STORAGE = 'mdbook-theme';
 
-const selectHandler = ev => {
-  if (document.getElementById(THEME_TOGGLE).contains(ev.target)) {
-    return;
-  }
-  if (!document.getElementById(THEME_LIST).contains(ev.target)) {
-    hideThemes();
-    return;
-  }
-  setTheme(ev.target.id);
-};
+const THEME_LIST = 'theme-list';
+const THEME_SELECTED = 'theme-selected';
 
-const hideThemes = () => {
-  document.getElementById(THEME_LIST).style.display = 'none';
-  document.getElementById(THEME_TOGGLE).setAttribute('aria-expanded', false);
-
-  document.removeEventListener('mouseup', selectHandler, { once: false, passive: true });
-};
-
-const showThemes = () => {
-  document.getElementById(THEME_LIST).style.display = 'block';
-  document.getElementById(THEME_TOGGLE).setAttribute('aria-expanded', true);
-
-  document.addEventListener('mouseup', selectHandler, { once: false, passive: true });
-};
+const htmlClassList = document.querySelector('html').classList;
 
 const setStyle = () => {
   document.querySelector('meta[name="theme-color"]').content = globalThis.getComputedStyle(
@@ -38,14 +14,13 @@ const setStyle = () => {
 };
 
 const setTheme = next => {
-  const htmlClass = document.querySelector('html').classList;
-  const current = htmlClass.value;
+  const current = htmlClassList.value;
 
   if (next === current) {
     return;
   }
 
-  htmlClass.replace(current, next);
+  htmlClassList.replace(current, next);
   setStyle();
 
   document.getElementById(current).classList.remove(THEME_SELECTED);
@@ -54,19 +29,15 @@ const setTheme = next => {
   writeLocalStorage(SAVE_STORAGE, next);
 };
 
-export const initThemeSelector = () => {
-  const theme = document.querySelector('html').classList.value;
-
-  document.querySelector('html').classList.add(theme);
+export const initTheme = () => {
+  document.querySelector('html').classList.add(htmlClassList.value);
   setStyle();
+};
 
-  document.getElementById(theme).classList.add(THEME_SELECTED);
+export const initThemeSelector = () => {
+  document.getElementById(htmlClassList.value).classList.add(THEME_SELECTED);
 
   document
-    .getElementById(THEME_TOGGLE)
-    .addEventListener(
-      'mouseup',
-      () => (document.getElementById(THEME_LIST).style.display === 'block' ? hideThemes() : showThemes()),
-      { once: false, passive: true },
-    );
+    .getElementById(THEME_LIST)
+    .addEventListener('mouseup', ev => setTheme(ev.target.id), { once: false, passive: true });
 };

--- a/scss/_chrome.scss
+++ b/scss/_chrome.scss
@@ -356,51 +356,65 @@ table {
   }
 }
 
-.theme-popup {
-  .theme {
-    width: 100%;
-    border: 0;
+:popover-open {
+  margin: 0;
+  top: var.$menu-bar-height;
+  left: 2.4rem;
+  border-radius: 0.4rem;
+  font-size: 0.7rem;
+  color: var(--fg);
+  background: var(--theme-popup-bg);
+  border: 0.1rem solid var(--theme-popup-border);
+
+  #theme-list {
     margin: 0;
-    padding: 0.2rem 1.25rem;
-    line-height: 1.5rem;
-    white-space: nowrap;
-    text-align: left;
-    cursor: pointer;
-    color: inherit;
-    background: inherit;
-    font-size: inherit;
+    padding: 0.4rem;
+    list-style-type: none;
 
-    &:hover {
-      background-color: var(--theme-hover);
+    .theme {
+      width: 100%;
+      border: 0;
+      padding: 0.2rem 1.25rem;
+      line-height: 1.5rem;
+      white-space: nowrap;
+      text-align: left;
+      cursor: pointer;
+      color: inherit;
+      background: inherit;
+      font-size: inherit;
+
+      &:hover {
+        background-color: var(--theme-hover);
+      }
     }
-  }
-}
 
-.theme-selected::before {
-  $theme-width: 1rem;
+    .theme-selected::before {
+      $theme-width: 1rem;
 
-  display: inline-block;
-  content: '✓';
-  margin-left: 0 - $theme-width;
-  width: $theme-width;
-}
+      display: inline-block;
+      content: '✓';
+      margin-left: 0 - $theme-width;
+      width: $theme-width;
+    }
 
-.tooltiptext {
-  position: absolute;
-  visibility: hidden;
-  color: #fff;
-  background-color: #333;
-  left: -1.8em;
-  top: -3.5em;
-  width: 4em;
-  height: 1em;
-  text-align: center;
-  border-radius: 0.8rem;
-  padding: 0.4em 0.8em;
-  margin: 0.4em;
+    .tooltiptext {
+      position: absolute;
+      visibility: hidden;
+      color: #fff;
+      background-color: #333;
+      left: -1.8em;
+      top: -3.5em;
+      width: 4em;
+      height: 1em;
+      text-align: center;
+      border-radius: 0.8rem;
+      padding: 0.4em 0.8em;
+      margin: 0.4em;
 
-  .tooltipped & {
-    visibility: visible;
+      .tooltipped & {
+        visibility: visible;
+      }
+    }
   }
 }
 

--- a/scss/general.scss
+++ b/scss/general.scss
@@ -64,27 +64,6 @@ body {
   min-height: calc(100dvh - var.$menu-bar-height);
 }
 
-.theme-popup {
-  position: absolute;
-  top: var.$menu-bar-height;
-  left: 2.4rem;
-  border-radius: 0.4rem;
-  font-size: 0.7rem;
-  color: var(--fg);
-  background: var(--theme-popup-bg);
-  border: 0.1rem solid var(--theme-popup-border);
-  list-style-type: none;
-  margin: 0;
-  padding: 0.4rem;
-  display: none;
-  overflow: hidden;
-  z-index: 30;
-
-  .default {
-    color: var(--icons);
-  }
-}
-
 .content {
   display: grid;
   grid-template-columns: 1rem 1fr 1rem;

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -35,19 +35,19 @@
     <div class="top-bar">
       <div id="menu-bar" class="menu-bar">
         <div class="left-buttons">
-          <button id="sidebar-toggle" class="icon-button" type="button" title="Toggle Table of Contents (Shortkey: T )" aria-label="Toggle Table of Contents" aria-controls="sidebar"></button>
-          <button id="theme-toggle" class="icon-button" type="button" title="Change theme" aria-label="Change theme"
+          <button id="sidebar-toggle" class="icon-button" title="Toggle Table of Contents (Shortkey: T )" aria-label="Toggle Table of Contents" aria-controls="sidebar"></button>
+          <button popovertarget="theme-popover" class="icon-button" title="Change theme" aria-label="Change theme"
   aria-haspopup="true" aria-expanded="false" aria-controls="theme-list"></button>
-          <ul id="theme-list" class="theme-popup" aria-label="Themes" role="menu">
-            <li role="none"><button role="menuitem" class="theme" id="au-lait">Au Lait</button></li>
-            <li role="none"><button role="menuitem" class="theme" id="latte">Latte</button></li>
-            <li role="none"><button role="menuitem" class="theme" id="frappe">Frappé</button></li>
-            <li role="none"><button role="menuitem" class="theme" id="macchiato">Macchiato</button></li>
-            <li role="none"><button role="menuitem" class="theme" id="mocha">Mocha</button></li>
-          </ul>
-
-          {{#if search_enabled}}
-          <button id="search-toggle" class="icon-button" type="button" title="Toggle Search Box (Shortkey: / )"
+            <div id="theme-popover" popover>
+              <ul id="theme-list" aria-label="Themes" role="menu">
+                <li role="none"><button role="menuitem" class="theme" id="au-lait">Au Lait</button></li>
+                <li role="none"><button role="menuitem" class="theme" id="latte">Latte</button></li>
+                <li role="none"><button role="menuitem" class="theme" id="frappe">Frappé</button></li>
+                <li role="none"><button role="menuitem" class="theme" id="macchiato">Macchiato</button></li>
+                <li role="none"><button role="menuitem" class="theme" id="mocha">Mocha</button></li>
+              </ul>
+            </div>
+          <button id="search-toggle" class="icon-button" title="Toggle Search Box (Shortkey: / )"
   aria-label="Toggle Search Box" aria-expanded="false" aria-keyshortcuts="S" aria-controls="searchbar"></button>
 
           <div id="search-wrapper" class="hidden">
@@ -60,7 +60,6 @@
               <ul id="searchresults"></ul>
             </div>
           </div>
-          {{/if}}
         </div>
 
         <div class="menu-title">{{ book_title }}</div>


### PR DESCRIPTION
Since `Firefox` 125.0.1 (Aprill 16, 2024), `popover` is apparently available by default.

> Firefox now supports the [popover](https://html.spec.whatwg.org/#the-popover-attribute) global attribute used for designating an element as a popover element. The element won't be rendered until it is made visible, after which it will appear on top of other page content.

refs: https://www.mozilla.org/en-US/firefox/125.0.1/releasenotes/

(`Safari` and `Chromium` were already supported long ago...)

This allows equivalent behaviour to be achieved while reducing JS processing compared to the past.

Isn't it about time we used it? 😏