### PR TITLE
Use `popover` to display `search results` 🐩

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -37,7 +37,7 @@ after = ["links"]
 
 [preprocessor.footnote]
 
-#[preprocessor.tailor]
+[preprocessor.tailor]
 
 
 # The following parameter settings are not available for this site.

--- a/book.toml
+++ b/book.toml
@@ -37,7 +37,7 @@ after = ["links"]
 
 [preprocessor.footnote]
 
-[preprocessor.tailor]
+#[preprocessor.tailor]
 
 
 # The following parameter settings are not available for this site.

--- a/js/searcher.js
+++ b/js/searcher.js
@@ -2,13 +2,13 @@ import Finder from './finder.js';
 import { initTableOfContents } from './table-of-contents.js';
 import { SearchResult, marking, unmarking } from './wasm_book.js';
 
-const ELEM_BAR = document.getElementById('searchbar');
 const ELEM_WRAPPER = document.getElementById('search-wrapper');
-const ELEM_RESULTS = document.getElementById('searchresults');
+const ELEM_BAR = document.getElementById('searchbar');
 const ELEM_ICON = document.getElementById('search-toggle');
 
-const ELEM_HEADER = document.getElementById('searchresults-header');
 const ELEM_OUTER = document.getElementById('searchresults-outer');
+const ELEM_HEADER = document.getElementById('searchresults-header');
+const ELEM_RESULTS = document.getElementById('searchresults');
 
 let searchResult;
 let finder;
@@ -63,7 +63,7 @@ const searchHandler = () => {
   prevTerms = terms;
 
   if (terms === '') {
-    ELEM_OUTER.classList.add('hidden');
+    ELEM_OUTER.hidePopover();
     return;
   }
 
@@ -82,20 +82,10 @@ const searchHandler = () => {
   ELEM_HEADER.innerText = `${results.length} search results for : ${terms}`;
   searchResult.append_search_result(results, terms);
 
-  ELEM_OUTER.classList.remove('hidden');
+  ELEM_OUTER.showPopover();
 };
 
-// TODO: This funny code is because Firefox still won't let me use Popover (by default)!
-const searchPopupHandler = ev => {
-  if (ELEM_WRAPPER.classList.contains('hidden') || ELEM_ICON.contains(ev.target)) {
-    return;
-  }
-
-  if (!ELEM_WRAPPER.contains(ev.target)) {
-    hiddenSearch();
-    return;
-  }
-
+const popupHandler = ev => {
   if (ev.target.tagName !== 'A') {
     return;
   }
@@ -113,16 +103,12 @@ const searchPopupHandler = ev => {
 const hiddenSearch = () => {
   ELEM_WRAPPER.classList.add('hidden');
   ELEM_ICON.setAttribute('aria-expanded', 'false');
-
-  document.removeEventListener('mouseup', searchPopupHandler, { once: false, passive: true });
 };
 
 const showSearch = () => {
   ELEM_WRAPPER.classList.remove('hidden');
   ELEM_ICON.setAttribute('aria-expanded', 'true');
   ELEM_BAR.select();
-
-  document.addEventListener('mouseup', searchPopupHandler, { once: false, passive: true });
 };
 
 export const initSearch = (root, config) => {
@@ -143,6 +129,20 @@ export const initSearch = (root, config) => {
   ELEM_ICON.addEventListener(
     'mouseup',
     () => (ELEM_WRAPPER.classList.contains('hidden') ? showSearch() : hiddenSearch()),
+    {
+      once: false,
+      passive: true,
+    },
+  );
+
+  ELEM_OUTER.addEventListener('mouseup', popupHandler, { once: false, passive: true });
+  ELEM_OUTER.addEventListener(
+    'beforetoggle',
+    ev => {
+      if (ev.newState === 'closed') {
+        hiddenSearch();
+      }
+    },
     { once: false, passive: true },
   );
 

--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v1.2.1';
+const CACHE_VERSION = 'v1.3.0';
 
 const CACHE_URL = '/commentary/';
 const CACHE_LIST = [

--- a/scss/_chrome.scss
+++ b/scss/_chrome.scss
@@ -358,44 +358,43 @@ table {
 
 :popover-open {
   margin: 0;
-  top: var.$menu-bar-height;
-  left: 2.4rem;
-  border-radius: 0.4rem;
-  font-size: 0.7rem;
   color: var(--fg);
   background: var(--theme-popup-bg);
   border: 0.1rem solid var(--theme-popup-border);
+  border-radius: 0.4rem;
+}
 
-  #theme-list {
-    margin: 0;
-    padding: 0.4rem;
-    list-style-type: none;
+#theme-list {
+  top: var.$menu-bar-height;
+  left: 2.4rem;
+  padding: 0.4rem;
+  list-style-type: none;
+  font-size: 0.7rem;
 
-    .theme {
-      width: 100%;
-      border: 0;
-      padding: 0.2rem 1.25rem;
-      line-height: 1.5rem;
-      white-space: nowrap;
-      text-align: left;
-      cursor: pointer;
-      color: inherit;
-      background: inherit;
-      font-size: inherit;
+  .theme {
+    width: 100%;
+    border: 0;
+    padding: 0.2rem 1.25rem;
+    line-height: 1.5rem;
+    white-space: nowrap;
+    text-align: left;
+    cursor: pointer;
+    color: inherit;
+    background: inherit;
+    font-size: inherit;
 
-      &:hover {
-        background-color: var(--theme-hover);
-      }
+    &:hover {
+      background-color: var(--theme-hover);
     }
+  }
 
-    .theme-selected::before {
-      $theme-width: 1rem;
+  .theme-selected::before {
+    $theme-width: 1rem;
 
-      display: inline-block;
-      content: '✓';
-      margin-left: 0 - $theme-width;
-      width: $theme-width;
-    }
+    display: inline-block;
+    content: '✓';
+    margin-left: 0 - $theme-width;
+    width: $theme-width;
   }
 }
 

--- a/scss/_chrome.scss
+++ b/scss/_chrome.scss
@@ -169,6 +169,49 @@ pre {
   }
 }
 
+:popover-open {
+  top: var.$menu-bar-height;
+
+  color: var(--fg);
+  background: var(--theme-popup-bg);
+  border: 0.1rem solid var(--theme-popup-border);
+}
+
+#theme-list {
+  margin: 0 2.4rem;
+  padding: 0.4rem;
+  list-style-type: none;
+  font-size: 0.7rem;
+
+  border-radius: 0.4rem;
+
+  .theme {
+    width: 100%;
+    border: 0;
+    padding: 0.2rem 1.25rem;
+    line-height: 1.5rem;
+    white-space: nowrap;
+    text-align: left;
+    cursor: pointer;
+    color: inherit;
+    background: inherit;
+    font-size: inherit;
+
+    &:hover {
+      background-color: var(--theme-hover);
+    }
+  }
+
+  .theme-selected::before {
+    $theme-width: 1rem;
+
+    display: inline-block;
+    content: '✓';
+    margin-left: 0 - $theme-width;
+    width: $theme-width;
+  }
+}
+
 .nav-wrapper {
   display: flex;
   justify-content: space-between;
@@ -271,6 +314,10 @@ table {
   padding-left: 0.5rem;
 }
 
+.search-wrapper {
+  flex-basis: 60%;
+}
+
 #searchbar {
   min-width: 10rem;
   height: 1.4rem;
@@ -282,55 +329,37 @@ table {
   color: var(--searchbar-fg);
 }
 
-.search-wrapper {
-  flex-basis: 60%;
-}
+#searchresults-outer {
+  width: 84dvw;
+  max-height: 88dvh;
+  margin: 0 auto;
+  overflow-y: scroll;
 
-#searchresults {
-  a {
-    color: var(--links);
-    text-decoration: none;
+  font-size: 0.9em;
+  padding: 0.8em;
+  border-radius: 1.6em;
+
+  &>#searchresults-header {
+    font-weight: bold;
+    padding: 1rem 0 0 0.3rem;
+    color: var(--searchresults-header-fg);
   }
 
-  div {
-    &#score {
+  ul {
+    list-style: none;
+    padding-left: 0.4rem;
+
+    a {
+      color: var(--links);
+      text-decoration: none;
+    }
+
+    #score {
       font-size: 0.6875rem;
       font-style: italic;
       color: var(--search-score);
       float: right;
     }
-  }
-}
-
-.searchresults-header {
-  font-weight: bold;
-  padding: 1rem 0 0 0.3rem;
-  color: var(--searchresults-header-fg);
-}
-
-.searchresults-outer {
-  width: 84dvw;
-  max-height: 88dvh;
-  overflow-y: scroll;
-
-  font-size: 0.9em;
-  position: absolute;
-
-  color: var(--fg);
-  background: var(--bg);
-
-  left: 50%;
-  transform: translate(-50%);
-
-  padding: 0.8em;
-
-  border: 0.1em solid var(--theme-popup-border);
-  border-radius: 1.6em;
-  z-index: 20;
-
-  ul {
-    list-style: none;
-    padding-left: 0.4rem;
 
     li {
       font-size: 0.9em;
@@ -353,48 +382,6 @@ table {
 
   mark {
     font-weight: bold;
-  }
-}
-
-:popover-open {
-  margin: 0;
-  color: var(--fg);
-  background: var(--theme-popup-bg);
-  border: 0.1rem solid var(--theme-popup-border);
-  border-radius: 0.4rem;
-}
-
-#theme-list {
-  top: var.$menu-bar-height;
-  left: 2.4rem;
-  padding: 0.4rem;
-  list-style-type: none;
-  font-size: 0.7rem;
-
-  .theme {
-    width: 100%;
-    border: 0;
-    padding: 0.2rem 1.25rem;
-    line-height: 1.5rem;
-    white-space: nowrap;
-    text-align: left;
-    cursor: pointer;
-    color: inherit;
-    background: inherit;
-    font-size: inherit;
-
-    &:hover {
-      background-color: var(--theme-hover);
-    }
-  }
-
-  .theme-selected::before {
-    $theme-width: 1rem;
-
-    display: inline-block;
-    content: '✓';
-    margin-left: 0 - $theme-width;
-    width: $theme-width;
   }
 }
 

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -36,17 +36,15 @@
       <div id="menu-bar" class="menu-bar">
         <div class="left-buttons">
           <button id="sidebar-toggle" class="icon-button" title="Toggle Table of Contents (Shortkey: T )" aria-label="Toggle Table of Contents" aria-controls="sidebar"></button>
-          <button popovertarget="theme-popover" class="icon-button" title="Change theme" aria-label="Change theme"
+          <button popovertarget="theme-list" class="icon-button" title="Change theme" aria-label="Change theme"
   aria-haspopup="true" aria-expanded="false" aria-controls="theme-list"></button>
-            <div id="theme-popover" popover>
-              <ul id="theme-list" aria-label="Themes" role="menu">
-                <li role="none"><button role="menuitem" class="theme" id="au-lait">Au Lait</button></li>
-                <li role="none"><button role="menuitem" class="theme" id="latte">Latte</button></li>
-                <li role="none"><button role="menuitem" class="theme" id="frappe">Frappé</button></li>
-                <li role="none"><button role="menuitem" class="theme" id="macchiato">Macchiato</button></li>
-                <li role="none"><button role="menuitem" class="theme" id="mocha">Mocha</button></li>
-              </ul>
-            </div>
+            <ul id="theme-list" aria-label="Themes" role="menu" popover>
+              <li role="none"><button role="menuitem" class="theme" id="au-lait">Au Lait</button></li>
+              <li role="none"><button role="menuitem" class="theme" id="latte">Latte</button></li>
+              <li role="none"><button role="menuitem" class="theme" id="frappe">Frappé</button></li>
+              <li role="none"><button role="menuitem" class="theme" id="macchiato">Macchiato</button></li>
+              <li role="none"><button role="menuitem" class="theme" id="mocha">Mocha</button></li>
+            </ul>
           <button id="search-toggle" class="icon-button" title="Toggle Search Box (Shortkey: / )"
   aria-label="Toggle Search Box" aria-expanded="false" aria-keyshortcuts="S" aria-controls="searchbar"></button>
 

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -53,8 +53,8 @@
               <input type="search" id="searchbar" name="searchbar" placeholder="Search this book ..."
                 aria-controls="searchresults-outer" aria-describedby="searchresults-header">
             </form>
-            <div id="searchresults-outer" class="searchresults-outer hidden">
-              <div id="searchresults-header" class="searchresults-header"></div>
+            <div id="searchresults-outer" popover>
+              <div id="searchresults-header"></div>
               <ul id="searchresults"></ul>
             </div>
           </div>


### PR DESCRIPTION
The display of `search results` was changed to a `popover` and the code around it was also reviewed.