### PR TITLE
Using Rust `1.79.0` 🕴🏻

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,6 +12,11 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
+      - name: Setup Rust
+        uses: hecrj/setup-rust-action@v2
+        with:
+          rust-version: "stable"
+
       - name: Checkout the repo
         uses: actions/checkout@v4
         with:
@@ -45,7 +50,7 @@ jobs:
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
           cargo install mdbook-admonish --version ^1.17
-          cargo install mdbook-tailor --version ^0.6
+          cargo install mdbook-tailor --version ^0.7
 
           cargo install wasm-bindgen-cli --version ^0.2
           cargo install wasm-pack --version ^0.12

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,8 +15,7 @@ jobs:
       - name: Setup Rust
         uses: hecrj/setup-rust-action@v2
         with:
-          rust-version: "stable"
-
+          rust-version: "1.79.0"
       - name: Checkout the repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `MSRV` of `bitstream-io` used by `mdbook-tailor` is now `1.79.0`.

https://crates.io/crates/bitstream-io

In line with this, the version of Rust needs to be raised to `1.79.0` when building this site (at least at the moment).

https://github.com/actions/runner-images/blob/macos-14-arm64/20240611.1/images/macos/macos-14-arm64-Readme.md

So use `setup-rust-action`!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions to set up Rust with version "1.79.0".
	- Upgraded `mdbook-tailor` to version `0.7`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->