### PR TITLE
Using `cache` in the test flow 🧀

### DIFF
--- a/.github/workflows/test-rs-footnote.yml
+++ b/.github/workflows/test-rs-footnote.yml
@@ -9,14 +9,31 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-
 jobs:
   test_job:
     runs-on: macos-14
     name: Testing
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - name: Checkout the repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache Cargo
+        id: cache-cargo
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          save-always: 'true'
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: "Test local rust"
         uses: Kristories/cargo-test@55a4112b486d64c66db881cdc80e7d66af5fe110 # v1.0.0
         with:
           manifest-path: './rs/mdbook-footnote/Cargo.toml'
+

--- a/.github/workflows/test-rs.yml
+++ b/.github/workflows/test-rs.yml
@@ -1,4 +1,4 @@
-name: test rs footnote
+name: test rs
 
 on:
   push:
@@ -12,7 +12,6 @@ env:
 jobs:
   test_job:
     runs-on: macos-14
-    name: Testing
     steps:
       - name: Checkout the repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -32,7 +31,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: "Test local rust"
+      - name: Test mdbook-footnote
         uses: Kristories/cargo-test@55a4112b486d64c66db881cdc80e7d66af5fe110 # v1.0.0
         with:
           manifest-path: './rs/mdbook-footnote/Cargo.toml'


### PR DESCRIPTION
Use cargo `cache` in the test flow as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved GitHub Actions workflows for testing Rust code:
		- Added caching of Cargo dependencies to enhance speed.
		- Updated steps to ensure better repository checkout procedures.
		- Introduced a new workflow for testing Rust code on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->