### PR TITLE
Set the order of execution for the workflow 🚗🚗

### DIFF
--- a/.github/workflows/test-rs.yml
+++ b/.github/workflows/test-rs.yml
@@ -1,10 +1,10 @@
 name: test rs
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_run:
+    workflows: ["github pages"]
+    types:
+      - completed
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
If `test rs` saves the cache first, the cache for `github pages` will not be saved.

> The cache created by `test rs` does not contain all the packages needed for `github pages`.

In this case, the next build will use the cache created by `test rs`.
(And an error will occur... 🤦🏻‍♀️)

So let's run `github pages` first and create a cache that reliably contains the packages we need!

This is the purpose of the PR.