### PR TITLE
The `deploy` is only done on the default branch 🌈

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: github-pages
+name: Build
 
 on:
   push:
@@ -253,24 +253,3 @@ jobs:
           path: book
           if-no-files-found: error
 
-  deploy-mdbook:
-    name: Deploy mdBook
-    runs-on: macos-14
-    needs: build-mdbook
-    steps:
-      - name: Download Book
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
-        with:
-          name: build-mdbook
-          path: book
-
-      - name: List Segments
-        run: |
-          ls -alR book
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
-        if: ${{ github.ref == 'refs/heads/main' }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: book

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   deploy-mdbook:
     name: Deploy mdBook
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     steps:
       - name: Download Book
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: [Build]
+    types:
+    - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-mdbook:
+    name: Deploy mdBook
+    runs-on: macos-14
+    steps:
+      - name: Download Book
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: build-mdbook
+          path: book
+
+      - name: List Segments
+        run: |
+          ls -alR book
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: book


### PR DESCRIPTION
#145 was a complete failure...

But it's not fun to end with that, so I guess we could at least separate `deploy`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Deploy" workflow that automates the deployment of mdBook documentation to GitHub Pages after a successful build.
  
- **Changes**
	- Renamed the existing workflow from "github-pages" to "Build" and removed the previous deployment job for better workflow clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->