### PR TITLE
ci: Try the `chrome` test 🥍

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,10 +46,18 @@ jobs:
         run: |
           firefox --version
 
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+
+      - name: Chrome Version
+        run: |
+          ${{ steps.setup-chrome.outputs.chrome-path }} --version
+
       - name: Test Wasm
         working-directory: rs/wasm
         run: |
-          wasm-pack test --headless --firefox
+          wasm-pack test --headless --firefox --chrome
 
       - name: Build Wasm
         working-directory: rs/wasm

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,13 +39,6 @@ jobs:
           sparse-checkout: |
             rs/wasm
 
-      - name: Setup Firefox
-        uses: browser-actions/setup-firefox@v1
-
-      - name: Firefox Version
-        run: |
-          firefox --version
-
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1
         id: setup-chrome
@@ -54,10 +47,17 @@ jobs:
         run: |
           ${{ steps.setup-chrome.outputs.chrome-path }} --version
 
+      - name: Setup Firefox
+        uses: browser-actions/setup-firefox@v1
+
+      - name: Firefox Version
+        run: |
+          firefox --version
+
       - name: Test Wasm
         working-directory: rs/wasm
         run: |
-          wasm-pack test --headless --firefox --chrome
+          wasm-pack test --headless --chrome --firefox
 
       - name: Build Wasm
         working-directory: rs/wasm

--- a/rs/wasm/webdriver.json
+++ b/rs/wasm/webdriver.json
@@ -1,9 +1,32 @@
 {
+	"goog:chromeOptions": {
+		"args": [
+			"--headless",
+			"--disable-gpu",
+      "--disable-dev-shm-usage",
+      "--window-size=1280,800",
+      "--enable-logging",
+      "--v=1",
+      "--no-first-run"
+		],
+    "prefs": {
+      "browser.startup.homepage": "about:blank",
+      "homepage": "about:blank",
+      "profile.default_content_setting_values.notifications": 2,
+      "session.restore_on_startup": 0
+    }
+	},
 	"moz:firefoxOptions": {
+		"args": [
+      "-headless",
+      "--disable-gpu",
+      "--window-size=1280,800"
+    ],
 		"prefs": {
-			"media.navigator.streams.fake": true,
+			"browser.startup.page": 0,
+			"browser.startup.homepage": "about:blank",
+			"devtools.console.stdout.content": true,
 			"media.navigator.permission.disabled": true
-		},
-		"args": []
+		}
 	}
 }


### PR DESCRIPTION
Could it be possible to test `chrome` using the same technique as #154?

I don't have chrome installed on my local environment, so I haven't been able to confirm that it works, but just give it a try!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced testing workflow for WebAssembly to include support for Chrome alongside Firefox.
  
- **Improvements**
	- Increased testing coverage for WebAssembly by ensuring compatibility across different web environments.
	- Improved browser configuration options to enhance headless operation for both Chrome and Firefox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->