### PR TITLE
Reduce testing time for `wasm` ⌛

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,17 +39,10 @@ jobs:
           sparse-checkout: |
             rs/wasm
 
-      - name: Setup Firefox
-        uses: browser-actions/setup-firefox@955a5d42b5f068a8917c6a4ff1656a2235c66dfb # v1
-
-      - name: Firefox Version
-        run: |
-          firefox --version
-
       - name: Test Wasm
         working-directory: rs/wasm
         run: |
-          wasm-pack test --headless --chrome --firefox
+          wasm-pack test --headless --chrome
 
   build-wasm:
     name: Build Wasm

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,14 +39,6 @@ jobs:
           sparse-checkout: |
             rs/wasm
 
-      - name: Setup Chrome
-        uses: browser-actions/setup-chrome@facf10a55b9caf92e0cc749b4f82bf8220989148 # v1
-        id: setup-chrome
-
-      - name: Chrome Version
-        run: |
-          ${{ steps.setup-chrome.outputs.chrome-path }} --version
-
       - name: Setup Firefox
         uses: browser-actions/setup-firefox@955a5d42b5f068a8917c6a4ff1656a2235c66dfb # v1
 


### PR DESCRIPTION
I just realised that `runner-image` already has `Google Chrome` installed.

Then why bother with the setup, right?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Streamlined the GitHub Actions workflow by removing Chrome setup steps, enhancing focus on Firefox testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->