### PR TITLE
Stop automatic review of `dependencies` by `coderabbitai` 🏷️

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,5 +11,6 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    labels: ["dependencies"]
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,6 +11,6 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    labels: ["dependencies"]
+    ignore_title_keywords: ["fix(deps):"]
 chat:
   auto_reply: true

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,4 +17,7 @@
     // Run lock file maintenance (updates) early Monday mornings.
     ":maintainLockFilesWeekly",
   ],
+  "labels": [
+    "dependencies"
+  },
 }


### PR DESCRIPTION
There is not much need for `coderabbitai` to perform automated reviews for `renovatebot` PRs.

I think a better way to solve this problem would be to use `labels`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an option to ignore specific commit title keywords in the auto-review settings, enhancing review flexibility.
	- Added a labeling feature for the Renovate bot's pull requests, improving organization for dependency-related updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->