### PR TITLE
Fix incorrect handling of `wasm` cache 🚰

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,7 +25,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: wasm-${{ runner.os }}-cargo
+          key: wasm-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Cargo
         if: steps.cache-cargo.outputs.cache-hit != 'true'
@@ -59,8 +59,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: wasm-${{ runner.os }}-cargo
-
+          key: wasm-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Cargo
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
If there is a `cache` of `wasm` builds, even if there is a version update of a dependent package, this has been ignored and the cache has been used.

Ex: https://github.com/CoralPink/commentary/actions/runs/10765002946/job/29848612782?pr=190

Naturally, we do not want the `Install Cargo` step to be skipped when there is a dependency update.

Probably due to not including (for some reason) a `hash` string in the key, so I'll add this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated caching keys in the GitHub Actions workflow to improve build efficiency by dynamically incorporating a hash of the `Cargo.lock` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->