### PR TITLE
Wouldn't you have to do a `checkout` first? 🧰

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,6 +15,12 @@ jobs:
     name: Test Wasm
     runs-on: macos-14
     steps:
+      - name: Checkout the repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          sparse-checkout: |
+            rs/wasm
+
       - name: Cache Cargo
         id: cache-cargo
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
@@ -32,12 +38,6 @@ jobs:
         run: |
           cargo install wasm-bindgen-cli
           cargo install wasm-pack
-
-      - name: Checkout the repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          sparse-checkout: |
-            rs/wasm
 
       - name: Test Wasm
         working-directory: rs/wasm
@@ -49,6 +49,12 @@ jobs:
     runs-on: macos-14
     needs: test-wasm
     steps:
+      - name: Checkout the repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          sparse-checkout: |
+            rs/wasm
+
       - name: Cache Cargo
         id: cache-cargo
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
@@ -65,12 +71,6 @@ jobs:
         run: |
           cargo install wasm-bindgen-cli
           cargo install wasm-pack
-
-      - name: Checkout the repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          sparse-checkout: |
-            rs/wasm
 
       - name: Build Wasm
         working-directory: rs/wasm


### PR DESCRIPTION
I have made changes to #192 but want to address the issue of not being able to retrieve the `hash` string.

Could this be due to the fact that the repository `checkout` is now done after the cache determination process?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced the CI/CD pipeline for better performance by optimizing the checkout process to focus on necessary files only.
	- Streamlined the workflow for "Test Wasm" and "Build Wasm" jobs, reducing unnecessary data transfer and improving efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->