### PR TITLE
fix: #207 💊

### DIFF
--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -24,7 +24,6 @@ const CACHE_LIST = [
   'woff/OpenSans-Italic.woff2',
   'woff/OpenSans-Regular.woff2',
   'woff/SourceCodePro-Medium.woff2',
-  'woff/NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.woff2',
 ];
 
 const FALLBACK_URL = `${CACHE_URL}chrome-96x96.png`;


### PR DESCRIPTION
refs: #207

With just this small change, `Nerd Fonts` should not request them when they are not needed,
but only when they are needed. (At that point the `woff2` file will be cached by `service workers`.)

This communication does not appear in the web inspector of the browser.
However, traces of the communication were clearly visible in the `http-server` that I usually use in my local environment!

The cache version is not updated in this PR, but should not be a problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed an unnecessary font resource from the service worker's cache list, optimizing caching efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->