### PR TITLE
Try to enable various operations on search popups 🍿

### DIFF
--- a/js/searcher.js
+++ b/js/searcher.js
@@ -66,8 +66,6 @@ const jumpUrl = aElement => {
     hiddenSearch();
     unmarkHandler();
     doSearchOrMarkFromUrl();
-
-    ELEM_RESULTS.removeEventListener('keydown', popupFocus);
   }
   window.location.href = url.href;
 };
@@ -84,7 +82,6 @@ const searchMouseupHandler = ev => {
 
   if (li !== focusedLi) {
     focusedLi = li;
-    li.focus();
     return;
   }
   jumpUrl(li.querySelector('a'));
@@ -119,8 +116,6 @@ const searchHandler = () => {
   }
   ELEM_HEADER.innerText = `${results.length} search results for : ${terms}`;
   searchResult.append_search_result(results, terms);
-
-  ELEM_RESULTS.addEventListener('keydown', popupFocus, { once: false, passive: true });
 };
 
 const hiddenSearch = () => {
@@ -128,6 +123,7 @@ const hiddenSearch = () => {
   ELEM_ICON.setAttribute('aria-expanded', 'false');
 
   ELEM_BAR.removeEventListener('keyup', searchHandler);
+  ELEM_RESULTS.removeEventListener('keyup', popupFocus);
   ELEM_OUTER.removeEventListener('mouseup', searchMouseupHandler);
 
   prevTerms = undefined;
@@ -138,6 +134,7 @@ const showSearch = () => {
   ELEM_ICON.setAttribute('aria-expanded', 'true');
 
   ELEM_BAR.addEventListener('keyup', searchHandler, { once: false, passive: true });
+  ELEM_RESULTS.addEventListener('keyup', popupFocus, { once: false, passive: true });
   ELEM_OUTER.addEventListener('mouseup', searchMouseupHandler, { once: false, passive: true });
 
   ELEM_BAR.select();

--- a/js/searcher.js
+++ b/js/searcher.js
@@ -57,6 +57,11 @@ const doSearchOrMarkFromUrl = () => {
 };
 
 const jumpUrl = aElement => {
+  if (aElement === null) {
+    console.warn('The link does not exist.');
+    return;
+  }
+
   const url = new URL(aElement.href);
 
   const clickedURL = url.origin + url.pathname;
@@ -79,6 +84,11 @@ const popupFocus = ev => {
 
 const searchMouseupHandler = ev => {
   const li = ev.target.closest('li');
+
+  if (li === null) {
+    console.warn('The li element does not exist.');
+    return;
+  }
 
   if (li !== focusedLi) {
     focusedLi = li;

--- a/js/searcher.js
+++ b/js/searcher.js
@@ -16,6 +16,7 @@ let searchResult;
 let finder;
 
 let prevTerms;
+let focusedLi;
 
 const unmarkHandler = () => {
   const main = document.getElementById('main');
@@ -56,17 +57,19 @@ const doSearchOrMarkFromUrl = () => {
 };
 
 const jumpUrl = aElement => {
-  const currentURL = window.location.origin + window.location.pathname;
-  const clickedURL = aElement.origin + aElement.pathname;
+  const url = new URL(aElement.href);
 
-  if (currentURL === clickedURL) {
+  const clickedURL = url.origin + url.pathname;
+  const currentURL = window.location.origin + window.location.pathname;
+
+  if (clickedURL === currentURL) {
     hiddenSearch();
     unmarkHandler();
     doSearchOrMarkFromUrl();
 
     ELEM_RESULTS.removeEventListener('keydown', popupFocus);
   }
-  aElement.click();
+  window.location.href = url.href;
 };
 
 const popupFocus = ev => {
@@ -77,14 +80,14 @@ const popupFocus = ev => {
 };
 
 const searchMouseupHandler = ev => {
-  if (ev.target.tagName !== 'A') {
+  const li = ev.target.closest('li');
+
+  if (li !== focusedLi) {
+    focusedLi = li;
+    li.focus();
     return;
   }
-  jumpUrl(ev.target);
-};
-
-const searchDblclickHandler = ev => {
-  jumpUrl(ev.target.closest('li').querySelector('a'));
+  jumpUrl(li.querySelector('a'));
 };
 
 const handleKeyup = ev => {
@@ -125,9 +128,7 @@ const hiddenSearch = () => {
   ELEM_ICON.setAttribute('aria-expanded', 'false');
 
   ELEM_BAR.removeEventListener('keyup', searchHandler);
-
   ELEM_OUTER.removeEventListener('mouseup', searchMouseupHandler);
-  ELEM_OUTER.removeEventListener('dblclick', searchDblclickHandler);
 
   prevTerms = undefined;
 };
@@ -137,9 +138,7 @@ const showSearch = () => {
   ELEM_ICON.setAttribute('aria-expanded', 'true');
 
   ELEM_BAR.addEventListener('keyup', searchHandler, { once: false, passive: true });
-
   ELEM_OUTER.addEventListener('mouseup', searchMouseupHandler, { once: false, passive: true });
-  ELEM_OUTER.addEventListener('dblclick', searchDblclickHandler, { once: false, passive: true });
 
   ELEM_BAR.select();
 };

--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v2.5.1';
+const CACHE_VERSION = 'v2.6.0';
 
 const CACHE_HOST = 'https://coralpink.github.io/';
 const CACHE_URL = '/commentary/';

--- a/rs/wasm/src/searcher/mod.rs
+++ b/rs/wasm/src/searcher/mod.rs
@@ -66,6 +66,9 @@ impl SearchResult {
             .ok_or("No element with ID `searchresults`")?;
 
         let li_element = document.create_element("li").expect("failed: create <li>");
+        li_element
+            .set_attribute("tabindex", "0")
+            .expect("failed: set tabindex");
 
         let url_table: Vec<String> = doc_urls
             .iter()
@@ -135,7 +138,7 @@ impl SearchResult {
             let score_bar = scoring_notation(el.score);
 
             self.add_element(&format!(
-                r#"<a href="{}{}?mark={}#{}">{}</a><span class="teaser" aria-label="Search Result Teaser">{}</span><div id="score">{}</div>"#,
+                r#"<a href="{}{}?mark={}#{}">{}</a><span aria-label="Search Result Teaser">{}</span><div id="score">{}</div>"#,
                 &self.path_to_root, page, mark, head, el.doc.breadcrumbs, teaser, score_bar
             ));
         });

--- a/scss/_chrome.scss
+++ b/scss/_chrome.scss
@@ -337,7 +337,7 @@ table {
   font-feature-settings: "palt";
 
   padding: 0.8em;
-  border-radius: 1.6em;
+  border-radius: 1rem;
 
   &>#searchresults-header {
     font-weight: bold;
@@ -346,40 +346,44 @@ table {
   }
 
   ul {
-    list-style: none;
     padding-left: 0.4rem;
 
-    a {
-      font-family: var.$italic-font;
-      font-style: italic;
-
-      color: var(--links);
-      text-decoration: none;
-    }
-
-    #score {
-      font-family: var.$italic-font;
-      font-style: italic;
-      font-size: 0.6875rem;
-
-      color: var(--search-score);
-      float: right;
-    }
-
     li {
-      font-size: 0.9em;
-      padding: 0.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4em;
 
-      &.focus {
+      font-size: .94em;
+      padding: .5rem;
+
+      cursor: pointer;
+
+      &:focus {
         background-color: var(--searchresults-li-bg);
+        border-radius: 0.4rem
       }
-    }
 
-    span {
-      &.teaser {
-        display: block;
-        clear: both;
-        margin: 0.4rem 0 0 1.25rem;
+      a {
+        font-family: var.$italic-font;
+        font-style: italic;
+
+        color: var(--links);
+        text-decoration: none;
+      }
+
+      span {
+        padding-left: 1em;
+      }
+
+      #score {
+        display: flex;
+        justify-content: flex-end;
+
+        color: var(--search-score);
+
+        font-family: var.$italic-font;
+        font-style: italic;
+        font-size: 0.6875rem;
       }
     }
   }

--- a/scss/_chrome.scss
+++ b/scss/_chrome.scss
@@ -1,9 +1,5 @@
 @use 'variables' as var;
 
-@view-transition {
-  navigation: auto;
-}
-
 .content {
   mark {
     cursor: pointer;
@@ -312,79 +308,3 @@ table {
   padding-left: 0.5rem;
 }
 
-.search-wrapper {
-  flex-basis: 60%;
-}
-
-#searchbar {
-  min-width: 10rem;
-  height: 1.4rem;
-  margin: 0.5rem 0.25rem;
-  padding: 0.5rem 1rem;
-  border: 0.1rem solid var(--searchbar-border-color);
-  border-radius: 1em;
-  background-color: var(--searchbar-bg);
-  color: var(--searchbar-fg);
-}
-
-#searchresults-outer {
-  width: 84dvw;
-  max-height: 88dvh;
-  margin: 0 auto;
-  overflow-y: scroll;
-
-  font-size: var.$base-font-size;
-  font-feature-settings: "palt";
-
-  padding: 0.8em;
-  border-radius: 1rem;
-
-  &>#searchresults-header {
-    font-weight: bold;
-    padding: 1rem 0 0 0.3rem;
-    color: var(--searchresults-header-fg);
-  }
-
-  ul {
-    padding-left: 0.4rem;
-
-    li {
-      display: flex;
-      flex-direction: column;
-      gap: 0.4em;
-
-      font-size: .94em;
-      padding: .5rem;
-
-      cursor: pointer;
-
-      &:focus {
-        background-color: var(--searchresults-li-bg);
-        border-radius: 0.4rem
-      }
-
-      a {
-        font-family: var.$italic-font;
-        font-style: italic;
-
-        color: var(--links);
-        text-decoration: none;
-      }
-
-      span {
-        padding-left: 1em;
-      }
-
-      #score {
-        display: flex;
-        justify-content: flex-end;
-
-        color: var(--search-score);
-
-        font-family: var.$italic-font;
-        font-style: italic;
-        font-size: 0.6875rem;
-      }
-    }
-  }
-}

--- a/scss/_search.scss
+++ b/scss/_search.scss
@@ -5,11 +5,10 @@
 }
 
 #searchbar {
-  min-width: 10rem;
-  height: 1.4rem;
-  margin: 0.5rem 0.25rem;
-  padding: 0.5rem 1rem;
-  border: 0.1rem solid var(--searchbar-border-color);
+  height: 2em;
+  margin: 0.5em 0.25em;
+  padding: 0.7em 1.4em;
+  border: 0.1em solid var(--searchbar-border-color);
   border-radius: 1em;
   background-color: var(--searchbar-bg);
   color: var(--searchbar-fg);

--- a/scss/_search.scss
+++ b/scss/_search.scss
@@ -1,0 +1,82 @@
+@use 'variables' as var;
+
+.search-wrapper {
+  flex-basis: 60%;
+}
+
+#searchbar {
+  min-width: 10rem;
+  height: 1.4rem;
+  margin: 0.5rem 0.25rem;
+  padding: 0.5rem 1rem;
+  border: 0.1rem solid var(--searchbar-border-color);
+  border-radius: 1em;
+  background-color: var(--searchbar-bg);
+  color: var(--searchbar-fg);
+}
+
+#searchresults-outer {
+  width: 84dvw;
+  max-height: 88dvh;
+  margin: 0 auto;
+  overflow-y: scroll;
+
+  font-size: var.$base-font-size;
+  font-feature-settings: "palt";
+
+  padding: 0.8em;
+  border-radius: 1rem;
+
+  &>#searchresults-header {
+    font-weight: bold;
+    padding: 1rem 0 0 0.3rem;
+    color: var(--searchresults-header-fg);
+  }
+
+  ul {
+    padding-left: 0.4rem;
+
+    li {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4em;
+
+      font-size: .94em;
+      padding: .5rem;
+
+      cursor: pointer;
+
+      &:focus {
+        outline: 0.2rem solid var(--links);
+
+        background-color: var(--searchresults-li-bg);
+        border-radius: 0.4rem
+      }
+
+      a {
+        pointer-events: none;
+
+        font-family: var.$italic-font;
+        font-style: italic;
+
+        color: var(--links);
+        text-decoration: none;
+      }
+
+      span {
+        padding-left: 1em;
+      }
+
+      #score {
+        display: flex;
+        justify-content: flex-end;
+
+        color: var(--search-score);
+
+        font-family: var.$italic-font;
+        font-style: italic;
+        font-size: 0.6875rem;
+      }
+    }
+  }
+}

--- a/scss/general.scss
+++ b/scss/general.scss
@@ -1,5 +1,9 @@
 @use 'variables' as var;
 
+@view-transition {
+  navigation: auto;
+}
+
 html {
   scroll-behavior: smooth;
   overflow-x: hidden;

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -14,3 +14,4 @@
 
 @use 'table-of-contents';
 @use 'footnote';
+@use 'search';


### PR DESCRIPTION
Currently, the only operation that can be performed in the search popup is to click on a link.

By applying this PR, the following operations will be possible

- `Tab` / `Shift+Tab` to select items and Enter key to jump
- ~~(for large areas within an item) `Double-click` to jump~~
- (for large areas within an item) Jump when clicked with focus

We have also improved the JS (mainly EventListener) and SCSS code.

The trade-off for the wider response range is that it now takes two clicks, whereas before it was simply one click.
That might bother you a bit.... 🐒

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced search functionality with new event handlers for improved interactivity.
	- Accessibility improvements with `tabindex` added to search result elements.
	- Introduction of a new SCSS file for comprehensive search interface styling.

- **Bug Fixes**
	- Streamlined HTML output of search results for better performance.

- **Style**
	- Updated styling for search results, including layout adjustments and focus states.
	- Added new view transition feature for smoother navigation.
	- Removed unused styles and optimized existing CSS for a cleaner structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->