### PR TITLE
Improved sidebar behavior - part2 🍌

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -265,11 +265,16 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2
         with:
-          mdbook-version: "0.4.41"
+          mdbook-version: "0.4.42"
 
       - name: Build mdBook
         run: |
           mdbook build
+
+      - name: Generate Page List
+        working-directory: book
+        run: |
+          sed -e 's/<li class="chapter-item expanded ">/<li class="chapter-item">/g' -e 's/ target="_parent"//g' toc.html > pagelist.html
 
       - name: Remove Unneeded Files
         working-directory: book

--- a/book.toml
+++ b/book.toml
@@ -13,10 +13,6 @@ create-missing = false
 git-repository-url = "https://github.com/CoralPink/commentary"
 site-url = "/commentary/"
 
-[output.html.fold]
-enable = false
-level = 2
-
 [output.html.playground]
 copy-js = false
 runnable = false
@@ -38,6 +34,12 @@ after = ["links"]
 
 [preprocessor.tailor]
 
+
+# Does not work on this site.
+
+#[output.html.fold]
+#enable = false
+#level = 0
 
 # The following is not used because the same functionality has been moved to `theme-selector.js`.
 

--- a/debug.sh
+++ b/debug.sh
@@ -4,7 +4,7 @@ pushd rs/wasm
 wasm-pack build --target web
 cp pkg/wasm_book.js ../../js
 cp pkg/wasm_book_bg.wasm ../../src
-pushd
+popd
 
 pushd js
 if [ ! -e ./node_modules ]; then
@@ -15,7 +15,7 @@ if [ ! -e ./highlight.js ]; then
 fi
 bun run build.js
 cp -r dist/. ../src/
-pushd
+popd
 
 pushd scss
 if [ ! -e ./node_modules ]; then
@@ -29,26 +29,32 @@ for theme in au-lait frappe latte macchiato mocha; do
     exit 1
   fi
 done
-pushd
+popd
 
 mdbook build --dest-dir commentary
 
-#rm commentary/ayu-highlight.css
-#rm commentary/clipboard.min.js
-#rm commentary/elasticlunr.min.js
-#rm commentary/favicon.png
-#rm commentary/fonts.css
-#rm commentary/highlight.css
-#rm commentary/highlight.js
-#rm commentary/searcher.js
-#rm commentary/toc.html
-#rm commentary/toc.js
-#rm commentary/tomorrow-night.css
-#rm commentary/css/chrome.css
-#rm commentary/css/variables.css
-#rm commentary/mark.min.js
-#rm -rf commentary/searchindex.js
-#rm -rf commentary/FontAwesome
-#rm -rf commentary/fonts
+pushd commentary
+sed -e 's/<li class="chapter-item expanded ">/<li class="chapter-item">/g' -e 's/ target="_parent"//g' toc.html > pagelist.html
+popd
+
+#pushd commentary
+#rm ayu-highlight.css
+#rm clipboard.min.js
+#rm elasticlunr.min.js
+#rm favicon.png
+#rm fonts.css
+#rm highlight.css
+#rm highlight.js
+#rm searcher.js
+#rm toc.html
+#rm toc.js
+#rm tomorrow-night.css
+#rm css/chrome.css
+#rm css/variables.css
+#rm mark.min.js
+#rm -rf searchindex.js
+#rm -rf FontAwesome
+#rm -rf fonts
+#popd
 
 echo '\n🐥 complete!'

--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v3.6.0';
+const CACHE_VERSION = 'v3.7.0';
 
 const CACHE_HOST = 'https://coralpink.github.io/';
 const CACHE_URL = '/commentary/';

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -78,10 +78,7 @@
     </div>
 
     <div id="page">
-      <aside id="sidebar" aria-label="Site map">
-        <nav id="sidebar-scrollbox" role="navigation" aria-live="polite" aria-busy="true"></nav>
-      </aside>
-
+      <aside id="sidebar" aria-label="Site map"></aside>
       <main>
         <article id="article">
           {{{ content }}}
@@ -102,7 +99,6 @@
           </nav>
         </article>
       </main>
-
       <aside id="table-of-contents"></aside>
     </div>
 

--- a/theme/toc.html.hbs
+++ b/theme/toc.html.hbs
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta name="robots" content="noindex">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+  </head>
+  <body>
+    <nav id="sidebar-scrollbox" role="navigation" aria-live="polite" aria-busy="true">
+      {{#toc}}{{/toc}}
+    </nav>
+  </body>
+</html>


### PR DESCRIPTION
The main purpose of this PR is to resolve #261.

> As discussed in PR #260, we need to automate the generation of the table of > contents using mdbook to avoid manual updates.

Generate and use a list of pages using the table of contents automatically generated by `mdbook`.

> [!Warning]
> This site uses the name `table of contents` for the list of headings within a page,
> so what is called a table of contents in `mdbook` is called a `page list` on this site.
> (Well, it's getting complicated 😅)

Perhaps embedding it in js would be more advantageous in terms of speed,
but the build order for this site is `bun` -> `mdbook`, which is a bit cumbersome.

So, knowing that this is not the intended use of mdbook,
I decided to use the html generated from `toc.html.hbs` with some modification.

Other special notes include the following.

- Use `mdbook v0.4.42
- I note as a comment that mdbook originally supported the folding feature, but this site does not at this time.
- Slightly improved behavior of `debug.sh