### PR TITLE
Cache generated fonts 🫕

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -205,6 +205,7 @@ jobs:
             fonts
 
       - name: Cache Woff2 output
+        id: cache-woff2
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
         with:
           path: fonts/woff2
@@ -213,36 +214,26 @@ jobs:
             python-${{ runner.os }}-fonts-
 
       - name: Install Poetry
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-woff2.outputs.cache-hit != 'true'
         run: |
           curl -sSL https://install.python-poetry.org | python -
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-woff2.outputs.cache-hit != 'true'
         working-directory: fonts
         run: |
           poetry install --no-root
 
-      - name: Make Directory
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: fonts
-        run: |
-          mkdir -p woff2
-
-      - name: Convert Woff2
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: fonts
-        run: |
-          poetry run python convert.py NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf woff2
-          poetry run python convert.py Open_Sans/static/OpenSans-BoldItalic.ttf woff2
-          poetry run python convert.py Open_Sans/static/OpenSans-Italic.ttf woff2
-
-      - name: Copy Woff2
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Convert and Copy Woff2
+        if: steps.cache-woff2.outputs.cache-hit != 'true'
         working-directory: fonts
         run: |
           set -e
+          mkdir -p woff2
+          poetry run python convert.py NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf woff2
+          poetry run python convert.py Open_Sans/static/OpenSans-BoldItalic.ttf woff2
+          poetry run python convert.py Open_Sans/static/OpenSans-Italic.ttf woff2
           cp "Fira Code/FiraCode-VF.woff2" woff2
 
       - name: Upload font artifacts

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -216,11 +216,7 @@ jobs:
       - name: Install Poetry
         if: steps.cache-woff2.outputs.cache-hit != 'true'
         run: |
-          curl -sSL https://install.python-poetry.org/install-poetry.py > install-poetry.py
-          gpg --keyserver hkps://keys.openpgp.org --recv-keys 4AC22D58E05B4C1B
-          curl -sSL https://install.python-poetry.org/install-poetry.py.asc > install-poetry.py.asc
-          gpg --verify install-poetry.py.asc install-poetry.py
-          python install-poetry.py
+          curl -sSL https://install.python-poetry.org | python -
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install Dependencies

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -216,7 +216,11 @@ jobs:
       - name: Install Poetry
         if: steps.cache-woff2.outputs.cache-hit != 'true'
         run: |
-          curl -sSL https://install.python-poetry.org | python -
+          curl -sSL https://install.python-poetry.org/install-poetry.py > install-poetry.py
+          gpg --keyserver hkps://keys.openpgp.org --recv-keys 4AC22D58E05B4C1B
+          curl -sSL https://install.python-poetry.org/install-poetry.py.asc > install-poetry.py.asc
+          gpg --verify install-poetry.py.asc install-poetry.py
+          python install-poetry.py
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install Dependencies

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -204,24 +204,34 @@ jobs:
           sparse-checkout: |
             fonts
 
+      - name: Cache Woff2 output
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        with:
+          path: fonts/woff2
+          key: python-${{ runner.os }}-fonts-${{ hashFiles('fonts/**') }}
+          restore-keys: |
+            python-${{ runner.os }}-fonts-
+
       - name: Install Poetry
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           curl -sSL https://install.python-poetry.org | python -
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        with:
-          path: /Users/runner/Library/Caches/pypoetry/virtualenvs
-          key: python-${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: python-${{ runner.os }}-poetry-
-
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         working-directory: fonts
         run: |
           poetry install --no-root
 
+      - name: Make Directory
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: fonts
+        run: |
+          mkdir -p woff2
+
       - name: Convert Woff2
+        if: steps.cache.outputs.cache-hit != 'true'
         working-directory: fonts
         run: |
           poetry run python convert.py NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf woff2
@@ -229,6 +239,7 @@ jobs:
           poetry run python convert.py Open_Sans/static/OpenSans-Italic.ttf woff2
 
       - name: Copy Woff2
+        if: steps.cache.outputs.cache-hit != 'true'
         working-directory: fonts
         run: |
           set -e

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -227,6 +227,7 @@ jobs:
         if: steps.cache-woff2.outputs.cache-hit != 'true'
         working-directory: fonts
         run: |
+          set -e
           poetry install --no-root
 
       - name: Convert and Copy Woff2


### PR DESCRIPTION
#276 adds font conversion, but this process can be time consuming, so cache the generated `woff2` file,
if your font directory (`font` files, `python` code, and packages) has not changed,
you should be able to skip most of the process using the cache.

Give it a try!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new job for converting font files to WOFF2 format, improving efficiency in the font conversion process.

- **Improvements**
	- Enhanced caching mechanism for WOFF2 output to optimize workflow performance.
	- Streamlined installation and conversion processes based on cache status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->