### PR TITLE
fix: Set appropriate aria for search results (#295) 🏒

### DIFF
--- a/js/searcher.js
+++ b/js/searcher.js
@@ -135,6 +135,10 @@ const searchMouseupHandler = ev => {
 };
 
 const focusinHandler = ev => {
+
+  // As far as I have tested, the order in which events are called is `focusin`->`click`.
+  // I have to call it in the order `click`->`focusin` or the expected behavior will not happen, so I am putting a delay on this process.
+  // If there is another solution, it should be changed immediately!!
   setTimeout(() => {
     elmPop.setAttribute('aria-activedescendant', ev.target.id);
 

--- a/js/searcher.js
+++ b/js/searcher.js
@@ -151,7 +151,7 @@ const focusinHandler = ev => {
     li.setAttribute('aria-selected', 'true');
 
     focusedLi = li;
-  }, 1);
+  }, 8);
 };
 
 const closedPopover = ev => {

--- a/js/searcher.js
+++ b/js/searcher.js
@@ -7,7 +7,6 @@ import { loadStyleSheet } from './css-loader.js';
 const STYLE_SEARCH = 'css/search.css';
 
 const ID_ICON = 'search-toggle';
-const ID_POP = 'search-pop';
 
 const INITIAL_HEADER = '2文字 (もしくは全角1文字) 以上を入力してください...';
 
@@ -16,6 +15,7 @@ const DEBOUNCE_DELAY_MS = 80;
 
 let rootPath;
 
+let elmPop;
 let elmSearchBar;
 let elmHeader;
 let elmResults;
@@ -87,20 +87,6 @@ const popupFocus = ev => {
   jumpUrl(ev.target.querySelector('a'));
 };
 
-const searchMouseupHandler = ev => {
-  const li = ev.target.closest('li');
-
-  if (li === null) {
-    return;
-  }
-
-  if (li !== focusedLi) {
-    focusedLi = li;
-    return;
-  }
-  jumpUrl(li.querySelector('a'));
-};
-
 const isFullWidthOrAscii = s => {
   const code = s.charCodeAt(0);
   return code <= 127 || (code >= 0xff01 && code <= 0xff5e);
@@ -135,6 +121,35 @@ const searchHandler = fn => {
   };
 };
 
+const searchMouseupHandler = ev => {
+  const li = ev.target.closest('li');
+
+  if (li === null) {
+    return;
+  }
+
+  if (focusedLi !== li) {
+    return;
+  }
+  jumpUrl(li.querySelector('a'));
+};
+
+const focusinHandler = ev => {
+  setTimeout(() => {
+    elmPop.setAttribute('aria-activedescendant', ev.target.id);
+
+    const li = ev.target.closest('li');
+
+    if (li === null) {
+      return;
+    }
+    focusedLi?.removeAttribute('aria-selected');
+    li.setAttribute('aria-selected', 'true');
+
+    focusedLi = li;
+  }, 1);
+};
+
 const closedPopover = ev => {
   if (ev.newState === 'closed') {
     hiddenSearch();
@@ -148,10 +163,11 @@ const hiddenSearch = () => {
 
   elmResults.removeEventListener('keyup', popupFocus);
 
-  const pop = document.getElementById(ID_POP);
-  pop.removeEventListener('click', searchMouseupHandler);
-  pop.removeEventListener('toggle', closedPopover);
-  pop.hidePopover();
+  elmPop.removeEventListener('click', searchMouseupHandler);
+  elmPop.removeEventListener('focusin', focusinHandler);
+  elmPop.removeEventListener('toggle', closedPopover);
+
+  elmPop.hidePopover();
 };
 
 const showSearch = () => {
@@ -163,10 +179,11 @@ const showSearch = () => {
 
   elmResults.addEventListener('keyup', popupFocus, { once: false, passive: true });
 
-  const pop = document.getElementById(ID_POP);
-  pop.addEventListener('click', searchMouseupHandler, { once: false, passive: true });
-  pop.addEventListener('toggle', closedPopover);
-  pop.showPopover();
+  elmPop.addEventListener('click', searchMouseupHandler, { once: false, passive: true });
+  elmPop.addEventListener('focusin', focusinHandler, { once: false, passive: true });
+  elmPop.addEventListener('toggle', closedPopover, { once: false, passive: true });
+
+  elmPop.showPopover();
 
   elmSearchBar.focus();
   elmSearchBar.select();
@@ -210,6 +227,7 @@ const initSearch = async () => {
     return;
   }
 
+  elmPop = document.getElementById('search-pop');
   elmSearchBar = document.getElementById('searchbar');
   elmHeader = document.getElementById('results-header');
   elmResults = document.getElementById('searchresults');
@@ -219,7 +237,7 @@ const initSearch = async () => {
   icon.addEventListener(
     'click',
     () => {
-      document.getElementById(ID_POP).checkVisibility() ? hiddenSearch() : showSearch();
+      elmPop.checkVisibility() ? hiddenSearch() : showSearch();
     },
     { once: false, passive: true },
   );
@@ -231,7 +249,7 @@ const initSearch = async () => {
         case '/':
         case 's':
         case 'S':
-          if (!document.getElementById(ID_POP).checkVisibility()) {
+          if (!elmPop.checkVisibility()) {
             showSearch();
           }
           break;

--- a/js/serviceworker.js
+++ b/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v4.4.4';
+const CACHE_VERSION = 'v4.5.0';
 
 const CACHE_HOST = 'https://coralpink.github.io/';
 const CACHE_URL = '/commentary/';

--- a/rs/wasm/Cargo.lock
+++ b/rs/wasm/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "macros"
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-book"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "js-sys",
  "macros",

--- a/rs/wasm/Cargo.toml
+++ b/rs/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-book"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["CoralPink <teqt6ytqt@mozmail.com>"]
 edition = "2021"
 rust-version = "1.74"

--- a/rs/wasm/src/searcher/mod.rs
+++ b/rs/wasm/src/searcher/mod.rs
@@ -86,7 +86,7 @@ impl SearchResult {
         })
     }
 
-    fn add_element(&self, content: &str, page: &str, score: &u16) {
+    fn add_element(&self, content: &str, id: &u16, page: &str, score: &u16) {
         let node: Node = self
             .li_element
             .clone_node_with_deep(true)
@@ -99,6 +99,10 @@ impl SearchResult {
                 return;
             }
         };
+
+        cloned_element
+            .set_attribute("id", &format!("s{id}"))
+            .expect("failed: set aria-label");
 
         cloned_element
             .set_attribute("aria-label", &format!("{page} {score}pt"))
@@ -124,6 +128,8 @@ impl SearchResult {
             .unwrap_or_default()
             .replace('\'', "%27");
 
+        let mut id_cnt = 0;
+
         result.into_iter().for_each(|el| {
             self.teaser.clear();
 
@@ -146,8 +152,10 @@ impl SearchResult {
             self.add_element(&format!(
                 r#"<a href="{}{}?mark={}#{}" tabindex="-1">{}</a><span aria-hidden="true">{}</span><div id="score" role="meter" aria-label="score:{}pt">{}</div>"#,
                 &self.path_to_root, page, mark, head, el.doc.breadcrumbs, result, el.score, score_bar),
-                page, &el.score
+                &id_cnt, page, &el.score
             );
+
+            id_cnt += 1;
         });
     }
 }


### PR DESCRIPTION
This PR adds `aria-activedescendant` to `search-pop` according to focus,
and also dynamically sets `aria-selected` for focused items.

Dynamically change the input bar (`searchbar`) or search result list items (`s0` to `sXXX`) depending on the focus.

Moving items with the up/down keys is not supported, but moving items with the `Tab/Shift-Tab` keys is supported.
(There is no possibility that the `up/down` keys will be supported in the future, but this will be discussed again when the opportunity arises.)

We believe that #302 and this PR have completed our response to the #295 issue!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced search result handling with unique element identifiers.
  - Improved search popover interaction and focus management.

- **Performance**
  - Updated service worker cache version to v4.5.0.

- **Package Updates**
  - Upgraded WASM package from version 0.6.1 to 0.7.0.

These updates improve the search experience, optimize caching, and prepare the application for future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->