### PR TITLE
fix: Improve focus management in search-pop component (#319) 🍿

### DIFF
--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -149,7 +149,9 @@ const updateFocus = (target: HTMLElement): void => {
   focusedLi?.removeAttribute('aria-selected');
   li.setAttribute('aria-selected', 'true');
 
-  elmPop.setAttribute('aria-activedescendant', target.id);
+  if (target.id) {
+    elmPop.setAttribute('aria-activedescendant', target.id);
+  }
   focusedLi = li;
 };
 
@@ -158,7 +160,13 @@ const popupFocus = (ev: KeyboardEvent): void => {
     updateFocus(ev.target as HTMLElement);
     return;
   }
-  jumpUrl();
+  try {
+    jumpUrl();
+  } catch (error) {
+    if (error instanceof SearchNavigationError) {
+      console.warn('popupFocus - Navigation error:', error.message);
+    }
+  }
 };
 
 const searchMouseupHandler = (ev: MouseEvent): void => {
@@ -168,7 +176,14 @@ const searchMouseupHandler = (ev: MouseEvent): void => {
   if (prevFocused !== focusedLi) {
     return;
   }
-  jumpUrl();
+
+  try {
+    jumpUrl();
+  } catch (error) {
+    if (error instanceof SearchNavigationError) {
+      console.warn('searchMouseupHandler - Navigation error:', error.message);
+    }
+  }
 };
 
 const closedPopover = (ev: Event): void => {

--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -76,39 +76,6 @@ const doSearchOrMarkFromUrl = (): void => {
   }
 };
 
-const jumpUrl = (aElement: HTMLAnchorElement): void => {
-  if (aElement === null) {
-    console.warn('The link does not exist.');
-    return;
-  }
-
-  const url = new URL(aElement.href);
-
-  const clickedURL = url.origin + url.pathname;
-  const currentURL = window.location.origin + window.location.pathname;
-
-  if (clickedURL === currentURL) {
-    hiddenSearch();
-    unmarkHandler();
-    doSearchOrMarkFromUrl();
-  }
-  window.location.href = url.href;
-};
-
-const popupFocus = (ev: KeyboardEvent): void => {
-  if (ev.key !== 'Enter') {
-    return;
-  }
-
-  const target = ev.target as HTMLElement;
-  const anchor = target.querySelector('a');
-
-  if (anchor === null) {
-    return;
-  }
-  jumpUrl(anchor);
-};
-
 const isFullWidthOrAscii = (s: string): boolean => {
   const code = s.charCodeAt(0);
   return code <= 127 || (code >= 0xff01 && code <= 0xff5e);
@@ -145,45 +112,57 @@ const searchHandler = (fn: () => void): (() => void) => {
   };
 };
 
-const searchMouseupHandler = (ev: MouseEvent): void => {
-  const target = ev.target as HTMLElement;
-  const li = target.closest('li');
+const jumpUrl = (): void => {
+  const aElement = focusedLi?.querySelector('a') as HTMLAnchorElement;
 
-  if (li === null) {
+  if (!aElement) {
+    console.warn('The link does not exist.');
     return;
   }
 
-  if (focusedLi !== li) {
-    return;
+  const url = new URL(aElement.href);
+
+  const clickedURL = url.origin + url.pathname;
+  const currentURL = window.location.origin + window.location.pathname;
+
+  if (clickedURL === currentURL) {
+    hiddenSearch();
+    unmarkHandler();
+    doSearchOrMarkFromUrl();
   }
 
-  const a = li.querySelector('a');
-
-  if (a === null) {
-    return;
-  }
-  jumpUrl(a);
+  window.location.href = url.href;
 };
 
-const focusinHandler = (ev: Event): void => {
-  const target = ev.target as HTMLElement;
+const updateFocus = (target: HTMLElement): void => {
+  const li = target.closest('li');
 
-  // As far as I have tested, the order in which events are called is `focusin`->`click`.
-  // I have to call it in the order `click`->`focusin` or the expected behavior will not happen, so I am putting a delay on this process.
-  // If there is another solution, it should be changed immediately!!
-  setTimeout(() => {
-    elmPop.setAttribute('aria-activedescendant', target.id);
+  if (!li || focusedLi === li) {
+    return;
+  }
+  focusedLi?.removeAttribute('aria-selected');
+  li.setAttribute('aria-selected', 'true');
 
-    const li = target.closest('li');
+  elmPop.setAttribute('aria-activedescendant', target.id);
+  focusedLi = li;
+};
 
-    if (li === null) {
-      return;
-    }
-    focusedLi?.removeAttribute('aria-selected');
-    li.setAttribute('aria-selected', 'true');
+const popupFocus = (ev: KeyboardEvent): void => {
+  if (ev.key !== 'Enter') {
+    updateFocus(ev.target as HTMLElement);
+    return;
+  }
+  jumpUrl();
+};
 
-    focusedLi = li;
-  }, 8);
+const searchMouseupHandler = (ev: MouseEvent): void => {
+  const prevFocused = focusedLi;
+  updateFocus(ev.target as HTMLElement);
+
+  if (prevFocused !== focusedLi) {
+    return;
+  }
+  jumpUrl();
 };
 
 const closedPopover = (ev: Event): void => {
@@ -201,7 +180,6 @@ const hiddenSearch = (): void => {
   elmResults.removeEventListener('keyup', popupFocus);
 
   elmPop.removeEventListener('click', searchMouseupHandler);
-  elmPop.removeEventListener('focusin', focusinHandler);
   elmPop.removeEventListener('toggle', closedPopover);
 
   elmPop.hidePopover();
@@ -217,7 +195,6 @@ const showSearch = (): void => {
   elmResults.addEventListener('keyup', popupFocus, { once: false, passive: true });
 
   elmPop.addEventListener('click', searchMouseupHandler, { once: false, passive: true });
-  elmPop.addEventListener('focusin', focusinHandler, { once: false, passive: true });
   elmPop.addEventListener('toggle', closedPopover, { once: false, passive: true });
 
   elmPop.showPopover();

--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -25,6 +25,13 @@ let finder: Finder;
 
 let focusedLi: Element;
 
+class SearchNavigationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SearchNavigationError';
+  }
+}
+
 const unmarkHandler = (): void => {
   const article = document.getElementById('article');
 
@@ -116,8 +123,7 @@ const jumpUrl = (): void => {
   const aElement = focusedLi?.querySelector('a') as HTMLAnchorElement;
 
   if (!aElement) {
-    console.warn('The link does not exist.');
-    return;
+    throw new SearchNavigationError('The link does not exist.');
   }
 
   const url = new URL(aElement.href);

--- a/js/serviceworker.ts
+++ b/js/serviceworker.ts
@@ -1,6 +1,6 @@
 declare const self: ServiceWorkerGlobalScope;
 
-const CACHE_VERSION = 'v5.0.3';
+const CACHE_VERSION = 'v5.0.4';
 
 const CACHE_HOST = 'https://coralpink.github.io/';
 const CACHE_URL = '/commentary/';


### PR DESCRIPTION
#319 issue, but I was able to achieve the same behavior without using `focusin`.
As far as I have checked, it seems to work in all browsers.

I got up unusually early today and watched Sanrio-chan.
It is really wonderful! Congratulations! 🎉

By the way, I wanted to buy a white cat ballerina kitty plushie, but I couldn't!
I wish there was a Sanrio shop in Kichijoji!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined search navigation and focus management for a smoother user experience, including improved error handling.
- **Chore**
	- Updated the service worker caching version to optimize cache management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->