### PR TITLE
Use `Brotli` only in `Safari` 18.4 or later 🥦

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -344,7 +344,6 @@ jobs:
       - name: Compress Search Index
         working-directory: book
         run: |
-          brew install brotli
           brotli searchindex.json
           gzip -k searchindex.json
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -274,7 +274,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: macos-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
+    #if: ${{ github.ref == 'refs/heads/main' }}
     needs: [build-wasm, build-js, build-scss, convert-woff2, test-mdbook-backend]
     steps:
       - name: Checkout the repo

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -274,7 +274,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: macos-latest
-    #if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: [build-wasm, build-js, build-scss, convert-woff2, test-mdbook-backend]
     steps:
       - name: Checkout the repo

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -344,7 +344,9 @@ jobs:
       - name: Compress Search Index
         working-directory: book
         run: |
-          gzip searchindex.json
+          brew install brotli
+          brotli searchindex.json
+          gzip -k searchindex.json
 
       - name: Remove Unneeded Files
         working-directory: book
@@ -356,14 +358,15 @@ jobs:
           rm fonts.css
           rm highlight.css
           rm highlight.js
+          rm mark.min.js
           rm searcher.js
           rm searchindex.js
+          rm searchindex.json
           rm toc.html
           rm toc.js
           rm tomorrow-night.css
           rm css/chrome.css
           rm css/variables.css
-          rm mark.min.js
           rm -rf FontAwesome
           rm -rf fonts
 

--- a/debug.sh
+++ b/debug.sh
@@ -51,7 +51,8 @@ sed \
 
 sed -E 's/^Object\.assign\(window\.search, //; s/\);$//' searchindex.js > searchindex.json
 jq empty searchindex.json && printf '    \e[1;32mFinished\e[0m convert search index \e[33m🧶Did it!!\e[0m\n'
-gzip searchindex.json
+brotli searchindex.json
+gzip -k searchindex.json
 popd
 
 #pushd commentary
@@ -62,14 +63,15 @@ popd
 #rm fonts.css
 #rm highlight.css
 #rm highlight.js
+#rm mark.min.js
 #rm searcher.js
 #rm searchindex.js
+#rm searchindex.json
 #rm toc.html
 #rm toc.js
 #rm tomorrow-night.css
 #rm css/chrome.css
 #rm css/variables.css
-#rm mark.min.js
 #rm -rf FontAwesome
 #rm -rf fonts
 #popd


### PR DESCRIPTION
I wish I could use `brotli` in all environments, but it doesn't seem to work.

The `node-zlib` and `Brotli.js` don't work with `bun`. (since they only provide a way to use `require()`)
On the other hand, `brotli-wasm` has a large binary size of its own and did not seem to be very suitable for the present purpose.

So, while I have faint hopes that `chromium` and `Firefox` will eventually support `DecompressionStream('brotli')`,
for now it is easiest to use the `brotli` file only in `Safari`.

However, the question remains if it is the best way to go,
so although I have created a PR, I'm not sure if I really want to merge this...😐

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced search performance: The search index now loads faster and more reliably by automatically optimizing data delivery based on your browser, delivering a smoother experience—especially for Safari users.
  - Improved compression methods for the search index, utilizing both Brotli and Gzip for better efficiency.
  
- **Chores**
  - Cleaned up unnecessary files during deployment to streamline the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->