### PR TITLE
View footnote on the fly 🛸

### DIFF
--- a/js/book.ts
+++ b/js/book.ts
@@ -1,4 +1,5 @@
 import { procCodeBlock } from './codeblock';
+import { initFootnote } from './footnote';
 import { startupSearch } from './searcher';
 import { initSidebar } from './sidebar';
 import { initTableOfContents } from './table-of-contents';
@@ -15,6 +16,8 @@ const initialize = (): void => {
 
   initThemeColor(rootPath);
   initTableOfContents();
+  initFootnote();
+
   procCodeBlock();
 
   initWasm().then(

--- a/js/footnote.ts
+++ b/js/footnote.ts
@@ -1,0 +1,59 @@
+const closePopover = (tip: HTMLElement) => {
+  tip.classList.remove('show');
+
+  const handleTransitionEnd = (event: TransitionEvent) => {
+    if (event.propertyName === 'opacity') {
+      tip.removeEventListener('transitionend', handleTransitionEnd);
+      tip.remove();
+    }
+  };
+
+  tip.addEventListener('transitionend', handleTransitionEnd);
+};
+
+const handleFootnoteClick = (target: EventTarget | null): void => {
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  const href = target.getAttribute('data-href');
+
+  if (!href) {
+    return;
+  }
+
+  const footnote = document.getElementById(href.slice(1));
+
+  if (!footnote) {
+    return;
+  }
+
+  const tip = document.createElement('aside');
+  tip.setAttribute('class', 'ft-pop');
+  tip.insertAdjacentHTML('afterbegin', footnote.innerHTML);
+
+  const onClickOutside = (ev: MouseEvent) => {
+    if (!(ev.target instanceof Node)) {
+      return;
+    }
+
+    if (!tip.contains(ev.target) && target !== ev.target) {
+      closePopover(tip);
+      document.removeEventListener('click', onClickOutside);
+    }
+  };
+
+  target.appendChild(tip);
+
+  requestAnimationFrame(() => {
+    tip.classList.add('show');
+  });
+
+  document.addEventListener('click', onClickOutside, { once: false, passive: true });
+};
+
+export const initFootnote = (): void => {
+  for (const sup of Array.from(document.querySelectorAll('sup.ft-reference'))) {
+    sup.addEventListener('click', ev => handleFootnoteClick(ev.target), { once: false, passive: true });
+  }
+};

--- a/js/footnote.ts
+++ b/js/footnote.ts
@@ -32,6 +32,31 @@ const handleFootnoteClick = (target: EventTarget | null): void => {
   tip.setAttribute('class', 'ft-pop');
   tip.insertAdjacentHTML('afterbegin', footnote.innerHTML);
 
+  tip.setAttribute('role', 'tooltip');
+  tip.setAttribute('id', `popover-${href.slice(1)}`);
+
+  target.setAttribute('aria-expanded', 'true');
+  target.setAttribute('aria-controls', `popover-${href.slice(1)}`);
+
+  document.body.appendChild(tip);
+
+  const rect = (target as HTMLElement).getBoundingClientRect();
+  const popHeight = tip.offsetHeight;
+  const gap = 10;
+  let top = rect.bottom + gap;
+
+  // Flip above if overflowing viewport bottom
+  if (top + popHeight > window.innerHeight - gap) {
+    top = rect.top - popHeight - gap;
+  }
+  tip.style.position = 'absolute';
+  tip.style.top = `${top + window.scrollY}px`;
+
+  requestAnimationFrame(() => {
+    tip.classList.add('show');
+  });
+
+  // Connect the button to the popover for accessibility
   const onClickOutside = (ev: MouseEvent) => {
     if (!(ev.target instanceof Node)) {
       return;
@@ -39,15 +64,13 @@ const handleFootnoteClick = (target: EventTarget | null): void => {
 
     if (!tip.contains(ev.target) && target !== ev.target) {
       closePopover(tip);
+
+      target.setAttribute('aria-expanded', 'false');
+      target.removeAttribute('aria-controls');
+
       document.removeEventListener('click', onClickOutside);
     }
   };
-
-  target.appendChild(tip);
-
-  requestAnimationFrame(() => {
-    tip.classList.add('show');
-  });
 
   document.addEventListener('click', onClickOutside, { once: false, passive: true });
 };

--- a/js/serviceworker.ts
+++ b/js/serviceworker.ts
@@ -1,6 +1,6 @@
 declare const self: ServiceWorkerGlobalScope;
 
-const CACHE_VERSION = 'v7.1.1';
+const CACHE_VERSION = 'v7.2.0';
 
 const CACHE_HOST = 'https://coralpink.github.io/';
 const CACHE_URL = '/commentary/';

--- a/rs/mdbook-footnote/Cargo.lock
+++ b/rs/mdbook-footnote/Cargo.lock
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-footnote"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "clap",
  "mdbook",

--- a/rs/mdbook-footnote/Cargo.toml
+++ b/rs/mdbook-footnote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-footnote"
-version = "1.5.0"
+version = "1.6.0"
 authors = ["David Drysdale <dmd@lurklurk.org>", "CoralPink"]
 edition = "2024"
 rust-version = "1.85"

--- a/rs/mdbook-footnote/src/lib.rs
+++ b/rs/mdbook-footnote/src/lib.rs
@@ -19,7 +19,7 @@ pub fn replacing(mut book: Book) -> Result<Book, Error> {
                     footnotes.push(content);
 
                     let idx = footnotes.len();
-                    format!("<sup class=\"{FT_REF}\"><a name=\"to-ft-{idx}\" href=\"#ft-{idx}\">{idx}</a></sup>")
+                    format!("<sup class=\"{FT_REF}\"><button id=\"to-ft-{idx}\" data-href=\"#ft-{idx}\">{idx}</button></sup>")
                 })
                 .to_string();
 

--- a/rs/mdbook-footnote/test/ok.md
+++ b/rs/mdbook-footnote/test/ok.md
@@ -1,7 +1,7 @@
 # 🎠 Watching the Wheels
 
 ```admonish success title=""
-I'm just sitting here watching the wheels<sup class="ft-reference"><a name="to-ft-1" href="#ft-1">1</a></sup>go 'round and 'round
+I'm just sitting here watching the wheels<sup class="ft-reference"><button id="to-ft-1" data-href="#ft-1">1</button></sup>go 'round and 'round
 
 I really love to watch them roll
 

--- a/scss/_footnote.scss
+++ b/scss/_footnote.scss
@@ -7,7 +7,7 @@
 
   a {
     text-decoration: none;
-  };
+  }
   p {
     display: inline;
   }
@@ -20,7 +20,7 @@
 
     background: none;
     border: none;
-    color: --links;
+    color: var(--links);
     cursor: pointer;
     padding: 0;
     font: inherit;
@@ -55,7 +55,13 @@
 
   a {
     text-decoration: none;
-  };
+
+    &:link, &:visited {
+      color: var(--links);
+      margin-left: .2em;
+      margin-right: .2em;
+    }
+  }
   p {
     display: inline;
   }

--- a/scss/_footnote.scss
+++ b/scss/_footnote.scss
@@ -7,16 +7,56 @@
 
   a {
     text-decoration: none;
-  }
-
+  };
   p {
     display: inline;
   }
 }
 
 .ft-reference {
-  a {
+  button {
     text-decoration: none;
     scroll-margin-top: var.$menu-bar-height;
+
+    background: none;
+    border: none;
+    color: --links;
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+  }
+}
+
+.ft-pop {
+  color: var(--fg);
+  background-color: var(--theme-popup-bg);
+  border: .1rem solid var(--theme-popup-border);
+
+  width: 88vw;
+  max-height: 64vw;
+  margin: 1rem auto;
+  padding: 1rem 1rem;
+  border-radius: .8rem;
+  font-size: .64rem;
+  text-align: left;
+  overflow-y: scroll;
+
+  position: absolute;
+  transform: translateX(-50%) scale(0.95);
+  left: 50%;
+  z-index: 20;
+  opacity: 0;
+  transition: opacity 150ms ease, transform 150ms ease;
+
+  &.show {
+    opacity: 1;
+    transform: translateX(-50%) scale(1);
+  }
+
+  a {
+    text-decoration: none;
+  };
+  p {
+    display: inline;
   }
 }


### PR DESCRIPTION
This PR is to allow footnotes on the site to be displayed on the fly.

I think I've packed in a reasonable amount of what I want to do,
but it's not the most flattering or sophisticated code, so if you have any good ideas, please let me know! 😣

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced interactive footnote popovers that appear when clicking on footnote references, enhancing readability and accessibility.
  - Footnote references now use buttons instead of links for improved interaction.

- **Style**
  - Updated footnote reference styling from links to buttons and added new styles for footnote popover appearance and transitions.

- **Chores**
  - Updated version numbers for both the service worker and the footnote package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->