### PR TITLE
Migrate from `poetry` to `uv` 🌞

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -216,28 +216,18 @@ jobs:
           restore-keys: |
             python-${{ runner.os }}-fonts-
 
-      - name: Install Poetry
-        if: steps.cache-woff2.outputs.cache-hit != 'true'
-        run: |
-          curl -sSL https://install.python-poetry.org | python -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Install Dependencies
-        if: steps.cache-woff2.outputs.cache-hit != 'true'
-        working-directory: fonts
-        run: |
-          set -e
-          poetry install
-
       - name: Convert and Copy Woff2
         if: steps.cache-woff2.outputs.cache-hit != 'true'
         working-directory: fonts
+        uses: astral-sh/setup-uv@v6.0.1
+        with:
+          version: "0.7.5"
         run: |
           set -e
           mkdir -p woff2
-          poetry run python convert.py NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf woff2
-          poetry run python convert.py Open_Sans/static/OpenSans-BoldItalic.ttf woff2
-          poetry run python convert.py Open_Sans/static/OpenSans-Italic.ttf woff2
+          uv run convert.py NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf woff2
+          uv run convert.py Open_Sans/static/OpenSans-BoldItalic.ttf woff2
+          uv run convert.py Open_Sans/static/OpenSans-Italic.ttf woff2
           cp "Fira Code/FiraCode-VF.woff2" woff2
 
       - name: Upload font artifacts

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -216,14 +216,15 @@ jobs:
           restore-keys: |
             python-${{ runner.os }}-fonts-
 
-      - name: Convert and Copy Woff2
-        if: steps.cache-woff2.outputs.cache-hit != 'true'
-        working-directory: fonts
+      - name: Setup Uv
         uses: astral-sh/setup-uv@v6.0.1
         with:
           version: "0.7.5"
+
+      - name: Convert and Copy Woff2
+        if: steps.cache-woff2.outputs.cache-hit != 'true'
+        working-directory: fonts
         run: |
-          set -e
           mkdir -p woff2
           uv run convert.py NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf woff2
           uv run convert.py Open_Sans/static/OpenSans-BoldItalic.ttf woff2

--- a/debug.sh
+++ b/debug.sh
@@ -19,10 +19,6 @@ cp -r dist/. ../src/
 popd
 
 if [ ! -e ./src/woff2 ]; then
-  if ! command -v uv >/dev/null; then
-    echo "Error: 'uv' is not installed. Install via 'pip install uv' or refer to project docs."
-    exit 1
-  fi
   pushd fonts
   mkdir -p ../src/woff2
   for font in \

--- a/debug.sh
+++ b/debug.sh
@@ -19,12 +19,20 @@ cp -r dist/. ../src/
 popd
 
 if [ ! -e ./src/woff2 ]; then
-pushd fonts
-uv run convert.py NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf ../src/woff2
-uv run convert.py Open_Sans/static/OpenSans-BoldItalic.ttf ../src/woff2
-uv run convert.py Open_Sans/static/OpenSans-Italic.ttf ../src/woff2
-cp Fira\ Code/FiraCode-VF.woff2 ../src/woff2
-popd
+  if ! command -v uv >/dev/null; then
+    echo "Error: 'uv' is not installed. Install via 'pip install uv' or refer to project docs."
+    exit 1
+  fi
+  pushd fonts
+  mkdir -p ../src/woff2
+  for font in \
+    "NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf" \
+    "Open_Sans/static/OpenSans-BoldItalic.ttf" \
+    "Open_Sans/static/OpenSans-Italic.ttf"; do
+    uv run convert.py "$font" ../src/woff2
+  done
+  cp "Fira Code/FiraCode-VF.woff2" ../src/woff2
+  popd
 fi
 
 pushd scss

--- a/debug.sh
+++ b/debug.sh
@@ -20,14 +20,9 @@ popd
 
 if [ ! -e ./src/woff2 ]; then
 pushd fonts
-python3 -m venv myenv
-source myenv/bin/activate
-pip install --upgrade pip
-pip install poetry
-poetry install
-poetry run python convert.py NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf ../src/woff2
-poetry run python convert.py Open_Sans/static/OpenSans-BoldItalic.ttf ../src/woff2
-poetry run python convert.py Open_Sans/static/OpenSans-Italic.ttf ../src/woff2
+uv run convert.py NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf ../src/woff2
+uv run convert.py Open_Sans/static/OpenSans-BoldItalic.ttf ../src/woff2
+uv run convert.py Open_Sans/static/OpenSans-Italic.ttf ../src/woff2
 cp Fira\ Code/FiraCode-VF.woff2 ../src/woff2
 popd
 fi

--- a/fonts/pyproject.toml
+++ b/fonts/pyproject.toml
@@ -12,10 +12,3 @@ dependencies = [
   "brotli ==1.1.0",
   "fonttools ==4.58.0",
 ]
-
-[tool.poetry]
-package-mode = false
-
-[build-system]
-requires = ["poetry-core>=2.0"]
-build-backend = "poetry.core.masonry.api"

--- a/fonts/uv.lock
+++ b/fonts/uv.lock
@@ -1,0 +1,55 @@
+version = 1
+revision = 2
+requires-python = ">=3.13, <4.0"
+
+[[package]]
+name = "brotli"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/c2/f9e977608bdf958650638c3f1e28f85a1b075f075ebbe77db8555463787b/Brotli-1.1.0.tar.gz", hash = "sha256:81de08ac11bcb85841e440c13611c00b67d3bf82698314928d0b676362546724", size = 7372270, upload-time = "2023-09-07T14:05:41.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/9f/fb37bb8ffc52a8da37b1c03c459a8cd55df7a57bdccd8831d500e994a0ca/Brotli-1.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8bf32b98b75c13ec7cf774164172683d6e7891088f6316e54425fde1efc276d5", size = 815681, upload-time = "2024-10-18T12:32:34.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b3/dbd332a988586fefb0aa49c779f59f47cae76855c2d00f450364bb574cac/Brotli-1.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7bc37c4d6b87fb1017ea28c9508b36bbcb0c3d18b4260fcdf08b200c74a6aee8", size = 422475, upload-time = "2024-10-18T12:32:36.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/80/6aaddc2f63dbcf2d93c2d204e49c11a9ec93a8c7c63261e2b4bd35198283/Brotli-1.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c0ef38c7a7014ffac184db9e04debe495d317cc9c6fb10071f7fefd93100a4f", size = 2906173, upload-time = "2024-10-18T12:32:37.978Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/e6ca79c96ff5b641df6097d299347507d39a9604bde8915e76bf026d6c77/Brotli-1.1.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91d7cc2a76b5567591d12c01f019dd7afce6ba8cba6571187e21e2fc418ae648", size = 2943803, upload-time = "2024-10-18T12:32:39.606Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a3/d98d2472e0130b7dd3acdbb7f390d478123dbf62b7d32bda5c830a96116d/Brotli-1.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a93dde851926f4f2678e704fadeb39e16c35d8baebd5252c9fd94ce8ce68c4a0", size = 2918946, upload-time = "2024-10-18T12:32:41.679Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a5/c69e6d272aee3e1423ed005d8915a7eaa0384c7de503da987f2d224d0721/Brotli-1.1.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f0db75f47be8b8abc8d9e31bc7aad0547ca26f24a54e6fd10231d623f183d089", size = 2845707, upload-time = "2024-10-18T12:32:43.478Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9f/4149d38b52725afa39067350696c09526de0125ebfbaab5acc5af28b42ea/Brotli-1.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6967ced6730aed543b8673008b5a391c3b1076d834ca438bbd70635c73775368", size = 2936231, upload-time = "2024-10-18T12:32:45.224Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5a/145de884285611838a16bebfdb060c231c52b8f84dfbe52b852a15780386/Brotli-1.1.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7eedaa5d036d9336c95915035fb57422054014ebdeb6f3b42eac809928e40d0c", size = 2848157, upload-time = "2024-10-18T12:32:46.894Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ae/408b6bfb8525dadebd3b3dd5b19d631da4f7d46420321db44cd99dcf2f2c/Brotli-1.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d487f5432bf35b60ed625d7e1b448e2dc855422e87469e3f450aa5552b0eb284", size = 3035122, upload-time = "2024-10-18T12:32:48.844Z" },
+    { url = "https://files.pythonhosted.org/packages/af/85/a94e5cfaa0ca449d8f91c3d6f78313ebf919a0dbd55a100c711c6e9655bc/Brotli-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:832436e59afb93e1836081a20f324cb185836c617659b07b129141a8426973c7", size = 2930206, upload-time = "2024-10-18T12:32:51.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f0/a61d9262cd01351df22e57ad7c34f66794709acab13f34be2675f45bf89d/Brotli-1.1.0-cp313-cp313-win32.whl", hash = "sha256:43395e90523f9c23a3d5bdf004733246fba087f2948f87ab28015f12359ca6a0", size = 333804, upload-time = "2024-10-18T12:32:52.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c1/ec214e9c94000d1c1974ec67ced1c970c148aa6b8d8373066123fc3dbf06/Brotli-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:9011560a466d2eb3f5a6e4929cf4a09be405c64154e12df0dd72713f6500e32b", size = 358517, upload-time = "2024-10-18T12:32:54.066Z" },
+]
+
+[[package]]
+name = "font-generate"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "brotli" },
+    { name = "fonttools" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "brotli", specifier = "==1.1.0" },
+    { name = "fonttools", specifier = "==4.58.0" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.58.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/cf/4d037663e2a1fe30fddb655d755d76e18624be44ad467c07412c2319ab97/fonttools-4.58.0.tar.gz", hash = "sha256:27423d0606a2c7b336913254bf0b1193ebd471d5f725d665e875c5e88a011a43", size = 3514522, upload-time = "2025-05-10T17:36:35.886Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/d7/d77cae11c445916d767cace93ba8283b3f360197d95d7470b90a9e984e10/fonttools-4.58.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4809790f2371d8a08e59e1ce2b734c954cf09742e75642d7f4c46cfdac488fdd", size = 2728320, upload-time = "2025-05-10T17:35:56.455Z" },
+    { url = "https://files.pythonhosted.org/packages/77/48/7d8b3c519ef4b48081d40310262224a38785e39a8610ccb92a229a6f085d/fonttools-4.58.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b00f240280f204ce4546b05ff3515bf8ff47a9cae914c718490025ea2bb9b324", size = 2302570, upload-time = "2025-05-10T17:35:58.794Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/48/156b83eb8fb7261056e448bfda1b495b90e761b28ec23cee10e3e19f1967/fonttools-4.58.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a62015ad463e1925544e9159dd6eefe33ebfb80938d5ab15d8b1c4b354ff47b", size = 4790066, upload-time = "2025-05-10T17:36:01.174Z" },
+    { url = "https://files.pythonhosted.org/packages/60/49/aaecb1b3cea2b9b9c7cea6240d6bc8090feb5489a6fbf93cb68003be979b/fonttools-4.58.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ceef6f6ab58061a811967e3e32e630747fcb823dcc33a9a2c80e2d0d17cb292", size = 4861076, upload-time = "2025-05-10T17:36:03.663Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c8/97cbb41bee81ea9daf6109e0f3f70a274a3c69418e5ac6b0193f5dacf506/fonttools-4.58.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c7be21ac52370b515cdbdd0f400803fd29432a4fa4ddb4244ac8b322e54f36c0", size = 4858394, upload-time = "2025-05-10T17:36:06.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/23/c2c231457361f869a7d7374a557208e303b469d48a4a697c0fb249733ea1/fonttools-4.58.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:85836be4c3c4aacf6fcb7a6f263896d0e9ce431da9fa6fe9213d70f221f131c9", size = 5002160, upload-time = "2025-05-10T17:36:08.178Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e0/c2262f941a43b810c5c192db94b5d1ce8eda91bec2757f7e2416398f4072/fonttools-4.58.0-cp313-cp313-win32.whl", hash = "sha256:2b32b7130277bd742cb8c4379a6a303963597d22adea77a940343f3eadbcaa4c", size = 2171919, upload-time = "2025-05-10T17:36:10.644Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ee/e4aa7bb4ce510ad57a808d321df1bbed1eeb6e1dfb20aaee1a5d9c076849/fonttools-4.58.0-cp313-cp313-win_amd64.whl", hash = "sha256:75e68ee2ec9aaa173cf5e33f243da1d51d653d5e25090f2722bc644a78db0f1a", size = 2222972, upload-time = "2025-05-10T17:36:12.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/1f/4417c26e26a1feab85a27e927f7a73d8aabc84544be8ba108ce4aa90eb1e/fonttools-4.58.0-py3-none-any.whl", hash = "sha256:c96c36880be2268be409df7b08c5b5dacac1827083461a6bc2cb07b8cbcec1d7", size = 1111440, upload-time = "2025-05-10T17:36:33.607Z" },
+]


### PR DESCRIPTION
The build itself is fine, but when I run `poetry self update` in my local environment, I get an error... 😿

I'm not in a very good mood, and at this point, I'm going to migrate to `uv` by the way! 🐶

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Simplified font conversion process by replacing Poetry with the uv tool.
  - Updated workflows and scripts to use uv for running Python scripts.
  - Removed Poetry-specific configurations from project files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->