### PR TITLE
Dealing `wasm-opt` call failures (for Rust 1.87) 🤙

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -79,10 +79,13 @@ jobs:
         run: |
           wasm-pack build --target web
 
+      - name: Install Binaryen
+        run: |
+          brew install binaryen
+
       - name: Optimization Wasm
         working-directory: rs/wasm
         run: |
-          brew install binaryen
           wasm-opt ./pkg/wasm_book_bg.wasm \
             -o ./pkg/wasm_book_bg.wasm \
             -O \

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -79,6 +79,16 @@ jobs:
         run: |
           wasm-pack build --target web
 
+      - name: Optimization Wasm
+        working-directory: rs/wasm
+        run: |
+          brew install binaryen
+          wasm-opt ./pkg/wasm_book_bg.wasm \
+            -o ./pkg/wasm_book_bg.wasm \
+            -O \
+            --enable-nontrapping-float-to-int \
+            --enable-bulk-memory
+
       - name: Upload wasm_pkg
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/debug.sh
+++ b/debug.sh
@@ -2,6 +2,11 @@ set -eu
 
 pushd rs/wasm
 wasm-pack build --target web
+wasm-opt ./pkg/wasm_book_bg.wasm \
+  -o ./pkg/wasm_book_bg.wasm \
+  -O \
+  --enable-nontrapping-float-to-int \
+  --enable-bulk-memory
 cp pkg/wasm_book.js ../../js
 cp pkg/wasm_book.d.ts ../../js
 cp pkg/wasm_book_bg.wasm ../../src

--- a/rs/wasm/Cargo.lock
+++ b/rs/wasm/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-book"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "arrayvec",
  "getset",

--- a/rs/wasm/Cargo.toml
+++ b/rs/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-book"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["CoralPink <teqt6ytqt@mozmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -44,3 +44,6 @@ features = [
 
 [dev-dependencies]
 wasm-bindgen-test = "=0.3.50"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false


### PR DESCRIPTION
With `Rust 1.87`, `wasm-pack` build` fails and build does not complete.

By the time CI's rust is updated, `wasm-pack` may already support it,
but we'll take care of it in advance just in case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Introduced an explicit WebAssembly optimization step in the build and debug processes, resulting in more efficient WebAssembly files.
	- Updated the package version to 1.0.4.
	- Adjusted build settings to disable default wasm-opt optimization during release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->