### PR TITLE
`SharedWorker` for more efficient operation 🌎

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -4,7 +4,7 @@ import { Buffer } from 'bun:buffer';
 
 import path from 'bun:path';
 
-const ENTRY_POINTS = ['book.ts', 'hl-worker.ts', 'replace-dom.ts', 'serviceworker.ts'];
+const ENTRY_POINTS = ['book.ts', 'hl-worker.ts', 'hl-sharedworker.ts', 'replace-dom.ts', 'serviceworker.ts'];
 const OUT_DIR = './dist';
 
 const CLR_RESET = '\x1b[0m';

--- a/js/codeblock.ts
+++ b/js/codeblock.ts
@@ -1,5 +1,5 @@
 import { initWorker } from './hl-initialize';
-import type { Payload, SendToWorker } from './hl-types';
+import { type SendToWorker, type Payload, isErrorPayload } from './hl-types';
 
 const TOOLTIP_FADEOUT_MS = 1200;
 
@@ -26,15 +26,16 @@ const copyCode = (target: EventTarget | null): void => {
     return;
   }
 
-  const pre = target.closest('pre');
-  const code = pre?.querySelector('code');
+  const code = target.closest('pre')?.querySelector('code');
 
-  if (code) {
-    navigator.clipboard.writeText(code.innerText).then(
-      () => showTooltip(target, 'Copied!'),
-      () => showTooltip(target, 'Failed...'),
-    );
+  if (!code) {
+    return;
   }
+
+  navigator.clipboard.writeText(code.innerText).then(
+    () => showTooltip(target, 'Copied!'),
+    () => showTooltip(target, 'Failed...'),
+  );
 };
 
 const highlight = (code: HTMLElement): void => {
@@ -45,6 +46,9 @@ const highlight = (code: HTMLElement): void => {
   }
 
   sendToWorker(code.textContent, code.classList[0], (res: Payload) => {
+    if (isErrorPayload(res)) {
+      return;
+    }
     code.setAttribute('translate', 'no');
     code.innerHTML = res.highlightCode;
 

--- a/js/codeblock.ts
+++ b/js/codeblock.ts
@@ -1,34 +1,10 @@
-const WORKER_PATH = '/commentary/hl-worker.js';
+import { initWorker } from './hl-initialize';
+import type { Payload, SendToWorker } from './hl-types';
 
 const TOOLTIP_FADEOUT_MS = 1200;
 
+let sendToWorker: SendToWorker;
 let clipButton: HTMLButtonElement;
-
-const observer = new IntersectionObserver(
-  entries => {
-    for (const entry of entries) {
-      if (entry.isIntersecting) {
-        const code = entry.target as HTMLElement;
-        highlight(code);
-
-        observer.unobserve(code);
-      }
-    }
-  },
-  { threshold: 0 },
-);
-
-const createClipButton = (): HTMLButtonElement => {
-  const elem = document.createElement('button');
-  elem.setAttribute('class', 'copy-button');
-  elem.setAttribute('aria-label', 'Copy to Clipboard');
-
-  const icon = document.createElement('div');
-  icon.setAttribute('class', 'icon-copy fa-icon');
-
-  elem.appendChild(icon);
-  return elem;
-};
 
 const showTooltip = (target: HTMLElement, msg: string): void => {
   const tip = document.createElement('div');
@@ -62,36 +38,55 @@ const copyCode = (target: EventTarget | null): void => {
 };
 
 const highlight = (code: HTMLElement): void => {
-  const worker = new Worker(WORKER_PATH);
-
-  worker.onmessage = (ev: MessageEvent) => {
-    const { highlightCode, needNerdFonts } = ev.data;
-    code.innerHTML = highlightCode;
-
-    if (needNerdFonts) {
-      code.style.fontFamily = `${window.getComputedStyle(code).fontFamily}, 'Symbols Nerd Font Mono'`;
-    }
-    code.setAttribute('translate', 'no');
-
-    worker.terminate();
-  };
-
-  worker.onerror = (err: ErrorEvent) => {
-    console.error('Error in codeBlock:', err);
-    worker.terminate();
-  };
-
-  worker.postMessage([code.textContent, code.classList[0]]);
-
   const parent = code.parentNode;
 
-  if (parent === null) {
+  if (parent === null || code.textContent === null) {
     return;
   }
-  const cb = document.importNode(clipButton, true);
-  cb.addEventListener('click', ev => copyCode(ev.target), { once: false, passive: true });
 
-  parent.insertBefore(cb, parent.firstChild);
+  sendToWorker(code.textContent, code.classList[0], (res: Payload) => {
+    code.setAttribute('translate', 'no');
+    code.innerHTML = res.highlightCode;
+
+    if (res.needNerdFonts) {
+      code.style.fontFamily = `${window.getComputedStyle(code).fontFamily}, 'Symbols Nerd Font Mono'`;
+    }
+
+    const cb = document.importNode(clipButton, true);
+    cb.addEventListener('click', ev => copyCode(ev.target), { once: false, passive: true });
+
+    parent.insertBefore(cb, parent.firstChild);
+  });
+};
+
+const observer = new IntersectionObserver(
+  entries => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) {
+        continue;
+      }
+
+      const code = entry.target as HTMLElement;
+      highlight(code);
+
+      observer.unobserve(code);
+    }
+  },
+  { threshold: 0 },
+);
+
+const createClipButton = (): HTMLButtonElement => {
+  const elm = document.createElement('button');
+
+  elm.setAttribute('class', 'copy-button');
+  elm.setAttribute('aria-label', 'Copy to Clipboard');
+
+  const icon = document.createElement('div');
+  icon.setAttribute('class', 'icon-copy fa-icon');
+
+  elm.appendChild(icon);
+
+  return elm;
 };
 
 export const initCodeBlock = (): void => {
@@ -101,11 +96,16 @@ export const initCodeBlock = (): void => {
     return;
   }
 
-  for (const x of Array.from(article.querySelectorAll('pre code')).filter(
-    (y): y is HTMLElement => !y.classList.contains('language-txt'),
-  )) {
-    observer.observe(x);
+  const codeBlocks = Array.from(article.querySelectorAll('pre code'));
+
+  if (codeBlocks.length === 0) {
+    return;
   }
 
   clipButton = createClipButton();
+  sendToWorker = initWorker();
+
+  for (const x of codeBlocks.filter((y): y is HTMLElement => !y.classList.contains('language-txt'))) {
+    observer.observe(x);
+  }
 };

--- a/js/hl-initialize.ts
+++ b/js/hl-initialize.ts
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview This module initializes a SharedWorker or a fallback Worker,
+ * depending on the platform support.
+ *
+ * It handles worker communication for syntax highlighting tasks.
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker
+ */
+import type { WorkerResponse, SendToWorker, Payload } from './hl-types';
+
+const SHAREDWORKER_PATH = '/commentary/hl-sharedworker.js';
+const WORKER_PATH = '/commentary/hl-worker.js';
+
+type WorkerCallback = (data: Payload) => void;
+
+/**
+ * Initializes a SharedWorker-based communication system.
+ *
+ * If supported, a single SharedWorker is reused across multiple connections.
+ * This helps reduce resource usage and enables inter-tab communication.
+ */
+const useSharedWorker = (): SendToWorker => {
+  const callbacks = new Map<number, WorkerCallback>();
+  let sharedId = 0;
+
+  const sharedWorker = new SharedWorker(SHAREDWORKER_PATH);
+  sharedWorker.port.start();
+
+  sharedWorker.port.onmessage = (ev: MessageEvent<WorkerResponse>) => {
+    const { id, payload } = ev.data;
+
+    callbacks.get(id)?.(payload);
+    callbacks.delete(id);
+  };
+
+  sharedWorker.onerror = (err: ErrorEvent) => {
+    console.error('SharedWorker error:', err);
+  };
+
+  return (text, lang, callback) => {
+    const id = sharedId++;
+
+    callbacks.set(id, callback);
+    sharedWorker.port.postMessage({ id, text, lang });
+  };
+};
+
+/**
+ * Initializes a simple dedicated Worker for each task.
+ *
+ * This is used as a fallback when SharedWorker is not available.
+ * Suitable for environments where SharedWorker is unsupported, such as Chrome on Android.
+ */
+const useSimpleWorker = (): SendToWorker => (text, lang, callback) => {
+  const worker = new Worker(WORKER_PATH);
+
+  worker.onmessage = (ev: MessageEvent<Payload>) => {
+    callback(ev.data);
+    worker.terminate();
+  };
+
+  worker.onerror = (err: ErrorEvent) => {
+    console.error('Error in fallback worker:', err);
+    worker.terminate();
+  };
+
+  worker.postMessage([text, lang]);
+};
+
+export const initWorker = (): SendToWorker => ('SharedWorker' in globalThis ? useSharedWorker : useSimpleWorker)();

--- a/js/hl-initialize.ts
+++ b/js/hl-initialize.ts
@@ -38,8 +38,12 @@ const useSharedWorker = (): SendToWorker => {
 
     if (isErrorPayload(payload)) {
       console.error(payload.error);
+    }
+
+    const callback = callbacks.get(id);
+    if (callback) {
+      callback(payload);
       callbacks.delete(id);
-      return;
     }
 
     callbacks.get(id)?.(payload);

--- a/js/hl-initialize.ts
+++ b/js/hl-initialize.ts
@@ -24,7 +24,13 @@ const useSharedWorker = (): SendToWorker => {
   const sharedWorker = new SharedWorker(SHAREDWORKER_PATH);
 
   sharedWorker.onerror = (err: ErrorEvent) => {
-    console.error('SharedWorker error:', err);
+    console.error(err);
+
+    // Notify pending callbacks of errors
+    for (const callback of callbacks.values()) {
+      callback({ error: 'Error in sharedworker' });
+    }
+    callbacks.clear();
   };
 
   sharedWorker.port.onmessage = (ev: MessageEvent<WorkerResponse>) => {

--- a/js/hl-language.ts
+++ b/js/hl-language.ts
@@ -1,0 +1,8 @@
+const LANGUAGE_PREFIX = 'language-';
+const LANGUAGE_PREFIX_LENGTH = LANGUAGE_PREFIX.length;
+export const extractLanguage = (s: string): string =>
+  s.startsWith(LANGUAGE_PREFIX) ? s.slice(LANGUAGE_PREFIX_LENGTH) : s;
+
+// Unicode Private Use Area (PUA) range used by Nerd Fonts
+const NERD_FONT_UNICODE_RANGE = /[\uE000-\uF8FF]/;
+export const containsNerdFontIcon = (text: string): boolean => NERD_FONT_UNICODE_RANGE.test(text);

--- a/js/hl-sharedworker.ts
+++ b/js/hl-sharedworker.ts
@@ -1,0 +1,32 @@
+// @ts-ignore
+import hljs from './highlight.js/build/highlight.js';
+import type { WorkerResponse } from './hl-types';
+
+const DELETEING_PREFIX_LENGTH = 'language-'.length;
+
+// Unicode Private Use Area (PUA) range used by Nerd Fonts
+const NERD_FONT_UNICODE_RANGE = /[\uE000-\uF8FF]/;
+const containsNerdFontIcon = (text: string): boolean => NERD_FONT_UNICODE_RANGE.test(text);
+
+type Request = {
+  id: number;
+  text: string;
+  lang: string;
+};
+
+(self as unknown as SharedWorkerGlobalScope).onconnect = ev => {
+  const port = ev.ports[0];
+
+  port.onmessage = (msg: MessageEvent<Request>) => {
+    const { id, text, lang } = msg.data;
+
+    const highlightCode = hljs.highlight(text, {
+      language: lang.slice(DELETEING_PREFIX_LENGTH),
+      ignoreIllegals: true,
+    }).value;
+
+    const needNerdFonts = containsNerdFontIcon(text);
+
+    port.postMessage({ id, payload: { highlightCode, needNerdFonts } } as WorkerResponse);
+  };
+};

--- a/js/hl-types.ts
+++ b/js/hl-types.ts
@@ -1,0 +1,11 @@
+export type Payload = {
+  highlightCode: string;
+  needNerdFonts: boolean;
+};
+
+export type WorkerResponse = {
+  id: number;
+  payload: Payload;
+};
+
+export type SendToWorker = (text: string, lang: string, callback: (payload: Payload) => void) => void;

--- a/js/hl-types.ts
+++ b/js/hl-types.ts
@@ -1,7 +1,11 @@
-export type Payload = {
-  highlightCode: string;
-  needNerdFonts: boolean;
-};
+type SuccessPayload = { highlightCode: string; needNerdFonts: boolean };
+type ErrorPayload = { error: string };
+
+export type Payload = SuccessPayload | ErrorPayload;
+
+export const isErrorPayload = (payload: Payload): payload is ErrorPayload => {
+  return 'error' in payload;
+}
 
 export type WorkerResponse = {
   id: number;

--- a/js/hl-worker.ts
+++ b/js/hl-worker.ts
@@ -4,9 +4,9 @@ import { extractLanguage, containsNerdFontIcon } from './hl-language.js';
 
 import type { Payload } from './hl-types';
 
-type HilightRequest = [text: string, lang: string];
+type HighlightRequest = [text: string, lang: string];
 
-self.onmessage = (ev: MessageEvent<HilightRequest>): void => {
+self.onmessage = (ev: MessageEvent<HighlightRequest>): void => {
   try {
     const highlightCode = hljs.highlight(ev.data[0], {
       language: extractLanguage(ev.data[1]),

--- a/js/hl-worker.ts
+++ b/js/hl-worker.ts
@@ -1,24 +1,23 @@
 // @ts-ignore
 import hljs from './highlight.js/build/highlight.js';
+import { extractLanguage, containsNerdFontIcon } from './hl-language.js';
 
-const DELETEING_PREFIX_LENGTH = 'language-'.length;
+import type { Payload } from './hl-types';
 
-// Unicode Private Use Area (PUA) range used by Nerd Fonts
-const NERD_FONT_UNICODE_RANGE = /[\uE000-\uF8FF]/;
-const containsNerdFontIcon = (text: string): boolean => NERD_FONT_UNICODE_RANGE.test(text);
+type HilightRequest = [text: string, lang: string];
 
-type PostMessageData = {
-  highlightCode: string;
-  needNerdFonts: boolean;
-};
+self.onmessage = (ev: MessageEvent<HilightRequest>): void => {
+  try {
+    const highlightCode = hljs.highlight(ev.data[0], {
+      language: extractLanguage(ev.data[1]),
+      ignoreIllegals: false,
+    }).value;
 
-self.onmessage = (ev: MessageEvent<[string, string]>): void => {
-  const highlightCode = hljs.highlight(ev.data[0], {
-    language: ev.data[1].slice(DELETEING_PREFIX_LENGTH),
-    ignoreIllegals: true,
-  }).value;
+    const needNerdFonts = containsNerdFontIcon(ev.data[0]);
 
-  const needNerdFonts = containsNerdFontIcon(ev.data[0]);
-
-  postMessage({ highlightCode, needNerdFonts } as PostMessageData);
+    postMessage({ highlightCode, needNerdFonts } as Payload);
+  } catch (err) {
+    const error = String(err instanceof Error ? err.message : err);
+    postMessage({ error } as Payload);
+  }
 };

--- a/js/serviceworker.ts
+++ b/js/serviceworker.ts
@@ -1,13 +1,12 @@
 declare const self: ServiceWorkerGlobalScope;
 
-const CACHE_VERSION = 'v7.3.0';
+const CACHE_VERSION = 'v7.4.0';
 
 const CACHE_URL = '/commentary/';
 const FALLBACK_IMAGE = 'chrome-96x96.png';
 
 const installList = [
   'book.js',
-  'hl-worker.js',
   'wasm_book_bg.wasm',
 
   'css/general.css',


### PR DESCRIPTION
Whereas previously a simple `Worker` was launched each time a block of code was displayed for the highlighting process, this PR uses a `SharedWorker` to make the site run more efficiently!

(In environments where `SharedWorker` is not available, use `Worker` as before.)

What’s different? | SharedWorker | Worker
-- | -- | --
How many? | Just one (shared across tabs) | One for every time you call it
Memory use | Pretty efficient (just one copy in memory) | Not great — makes a new one each time
Startup time | Starts once and keeps running | Starts fresh every time
Best for | When tabs need to talk to each other or share data | When everything’s separate and self-contained
Isolation | Shared, so not totally isolated | Fully separate from the rest
Browser support | Not available on Chrome Android | Works pretty much everywhere

> note: **Chrome Android** doesn’t support `SharedWorker` — see [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker) for details.

Very interesting! 😼

But it's a big change, so let's go carefully.
To be continued on Monday! 🌝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced improved syntax highlighting powered by a SharedWorker, enabling faster and more efficient code highlighting across multiple tabs.
  - Enhanced detection of code blocks that require Nerd Fonts for accurate display.

- **Refactor**
  - Streamlined the code highlighting process to use a centralized worker, reducing resource usage and improving performance.
  - Updated the build process to include new worker scripts for syntax highlighting.

- **Chores**
  - Updated internal cache versioning for the service worker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->