### PR TITLE
Cache media files stored in `lfs` 🌵

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,6 +17,13 @@ jobs:
     name: Cache Media Files
     runs-on: macos-15
     steps:
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          lfs: false
+          sparse-checkout: |
+            src
+
       - name: Cache Source
         id: cache-source
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
@@ -27,13 +34,11 @@ jobs:
             src/**/*.mp3
           key: media-${{ hashFiles('src/**/*.webp', 'src/**/*.webm', 'src/**/*.mp3') }}
 
-      - name: Checkout the repo
+      - name: Ensure LFS Files Are Pulled
         if: steps.cache-source.outputs.cache-hit != 'true'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           lfs: true
-          sparse-checkout: |
-            src
+        run: git lfs pull
 
   test-wasm:
     name: Test Wasm
@@ -300,7 +305,7 @@ jobs:
       contents: write
     name: Build and Deploy
     runs-on: macos-15
-    if: ${{ github.ref == 'refs/heads/main' }}
+#    if: ${{ github.ref == 'refs/heads/main' }} # Temporarily disabled for operation check...
     needs: [build-wasm, build-js, build-scss, cache-media-files, convert-woff2, test-mdbook-backend]
     steps:
       - name: Restore Media Cache
@@ -417,6 +422,7 @@ jobs:
         run: |
           ls -alR book
 
+# Temporarily disabled for operation check...
 #     - name: Deploy
 #       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
 #       with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  cache-media-files:
+    name: Cache Media Files
+    runs-on: macos-15
+    steps:
+      - name: Cache Source
+        id: cache-source
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: |
+            src/**/*.webp
+            src/**/*.webm
+            src/**/*.mp3
+          key: media-${{ hashFiles('src/**/*.webp', 'src/**/*.webm', 'src/**/*.mp3') }}
+
+      - name: Checkout the repo
+        if: steps.cache-source.outputs.cache-hit != 'true'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          lfs: true
+          sparse-checkout: |
+            src
+
   test-wasm:
     name: Test Wasm
     runs-on: macos-15
@@ -279,8 +301,21 @@ jobs:
     name: Build and Deploy
     runs-on: macos-15
     if: ${{ github.ref == 'refs/heads/main' }}
-    needs: [build-wasm, build-js, build-scss, convert-woff2, test-mdbook-backend]
+    needs: [build-wasm, build-js, build-scss, cache-media-files, convert-woff2, test-mdbook-backend]
     steps:
+      - name: Restore Media Cache
+        id: cache-media
+        uses: actions/cache@v4
+        with:
+          path: tmp-media
+          key: media-${{ hashFiles('src/**/*.webp', 'src/**/*.webm', 'src/**/*.mp3') }}
+
+      - name: Fail If Media Cache Not Found
+        if: steps.cache-media.outputs.cache-hit != 'true'
+        run: |
+          echo "Media cache not found. Stopping the workflow..."
+          exit 1
+
       - name: Checkout the repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -291,6 +326,14 @@ jobs:
             scripts
             src
             theme
+
+      - name: Remove LFS Pointer
+        run: find src -type f \( -name '*.webp' -o -name '*.webm' -o -name '*.mp3' \) -delete
+
+      - name: Copy Cached Media Back
+        run: |
+          rsync -a tmp-media/ src/
+          rm -rf tmp-media
 
       - name: Download All Artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
Inadvertently used `lfs`, and the data transfer limit, which I didn't have to worry about before, imposed a big constraint on my deployments....

This PR attempts to somehow alleviate this constraint by using cache.

My guess is that it is not possible to change or delete media files on a per media file basis
(but as far as deletion is concerned, this can be handled on the surface by simply cutting references from the site html).

So if these are needed, the cache must be deleted beforehand, but adding media files should be possible with minimal transfer.