### PR TITLE
Support for adding differences in media files 🍽

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,6 +19,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     outputs:
       media-cache-key: ${{ steps.set-cache-key.outputs.cache-key }}
+      cache-hit-exact: ${{ steps.check-cache.outputs.exact }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -32,20 +33,31 @@ jobs:
         run: |
           echo "cache-key=media-${{ hashFiles('src/**/*.webp', 'src/**/*.webm', 'src/**/*.mp3') }}" >> $GITHUB_OUTPUT
 
-      - name: Cache Source
+      - name: Restore Media Cache (allow partial match)
         id: cache-source
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: tmp-media
           key: media-${{ hashFiles('src/**/*.webp', 'src/**/*.webm', 'src/**/*.mp3') }}
+          restore-keys: media-
 
-      - name: Ensure LFS Files Are Pulled
-        if: steps.cache-source.outputs.cache-hit != 'true'
+      - name: Check if cache is exact match
+        id: check-cache
+        run: |
+          if [ "${{ steps.cache-source.outputs.cache-hit }}" = "true" ] && \
+             [ "${{ steps.set-cache-key.outputs.cache-key }}" = "media-${{ hashFiles('src/**/*.webp', 'src/**/*.webm', 'src/**/*.mp3') }}" ]; then
+            echo "exact=true" >> $GITHUB_OUTPUT
+          else
+            echo "exact=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Pull missing LFS files (on partial or miss)
+        if: steps.check-cache.outputs.exact != 'true'
         run: |
           git lfs pull
 
       - name: Synchronize Media Files
-        if: steps.cache-source.outputs.cache-hit != 'true'
+        if: steps.check-cache.outputs.exact != 'true'
         run: |
           mkdir tmp-media
           rsync -a --include='*/' --include='*.webp' --include='*.webm' --include='*.mp3' --exclude='*' src/ tmp-media

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -452,8 +452,8 @@ jobs:
         run: |
           ls -alR book
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: book
+#      - name: Deploy
+#        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          publish_dir: book

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Restore Media Cache (allow partial match)
         id: cache-source
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: tmp-media
           key: media-${{ hashFiles('src/**/*.webp', 'src/**/*.webm', 'src/**/*.mp3') }}
@@ -45,7 +45,7 @@ jobs:
         id: check-cache
         run: |
           if [ "${{ steps.cache-source.outputs.cache-hit }}" = "true" ] && \
-             [ "${{ steps.set-cache-key.outputs.cache-key }}" = "media-${{ hashFiles('src/**/*.webp', 'src/**/*.webm', 'src/**/*.mp3') }}" ]; then
+             [ "${{ steps.cache-source.outputs.cache-matched-key }}" = "${{ steps.set-cache-key.outputs.cache-key }}" ]; then
             echo "exact=true" >> $GITHUB_OUTPUT
           else
             echo "exact=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: tmp-media
-          key: media-${{ hashFiles('src/**/*.webp', 'src/**/*.webm', 'src/**/*.mp3') }}
+          key: ${{ steps.set-cache-key.outputs.cache-key }}
           restore-keys: media-
 
       - name: Check if cache is exact match

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -59,8 +59,22 @@ jobs:
       - name: Synchronize Media Files
         if: steps.check-cache.outputs.exact != 'true'
         run: |
-          mkdir tmp-media
-          rsync -a --include='*/' --include='*.webp' --include='*.webm' --include='*.mp3' --exclude='*' src/ tmp-media
+          rm -rf tmp-media
+          mkdir -p tmp-media
+          rsync -a --delete \
+            --include='*/' \
+            --include='*.webp' \
+            --include='*.webm' \
+            --include='*.mp3' \
+            --exclude='*' \
+            src/ tmp-media
+
+      - name: Save Media Cache (new primary key)
+        if: steps.check-cache.outputs.exact != 'true'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        with:
+          path: tmp-media
+          key: ${{ steps.set-cache-key.outputs.cache-key }}
 
   test-wasm:
     name: Test Wasm

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -54,8 +54,7 @@ jobs:
       - name: Pull missing LFS files (on partial or miss)
         if: steps.check-cache.outputs.exact != 'true'
         run: |
-          git lfs pull
-
+          git lfs pull --include="src/**/*.webp,src/**/*.webm,src/**/*.mp3"
       - name: Synchronize Media Files
         if: steps.check-cache.outputs.exact != 'true'
         run: |


### PR DESCRIPTION
#492 is lost in translation while doing various things, and I don't think it can handle the addition of media file diffs that I originally envisioned.

This PR has made every effort to support differential files, but we do not want to overwhelm the transfer volume by performing a behavior check here...😣

Therefore, the relevant code will not be checked in this PR, but if you can see from the code that it is clearly behaving strangely, please let us know!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Improved gh-pages media caching to detect exact vs partial cache hits.
  - Conditional media synchronization now runs only when the cache isn't an exact match, reducing unnecessary work.
  - Missing media files are automatically pulled on partial/miss to ensure assets are present.
  - Media sync now mirrors content cleanly and updated caches are saved with a new primary key to speed future runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->