### PR TITLE
Use deploy-pages 🧁

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,7 +16,6 @@ jobs:
   cache-media-files:
     name: Cache Media Files
     runs-on: macos-15
-    if: ${{ github.ref == 'refs/heads/main' }}
     outputs:
       media-cache-key: ${{ steps.set-cache-key.outputs.cache-key }}
       cache-hit-exact: ${{ steps.check-cache.outputs.exact }}
@@ -47,7 +44,8 @@ jobs:
       - name: Check if cache is exact match
         id: check-cache
         run: |
-          if [ "${{ steps.cache-source.outputs.cache-hit }}" = "true" ] && \
+          if [ "${GITHUB_REF}" == "refs/heads/main" ] && \
+             [ "${{ steps.cache-source.outputs.cache-hit }}" = "true" ] && \
              [ "${{ steps.cache-source.outputs.cache-matched-key }}" = "${{ steps.set-cache-key.outputs.cache-key }}" ]; then
             echo "exact=true" >> $GITHUB_OUTPUT
           else
@@ -363,7 +361,7 @@ jobs:
         with:
           path: tmp-media
           key: ${{ needs.cache-media-files.outputs.media-cache-key }}
-          fail-on-cache-miss: true
+          fail-on-cache-miss: false # If there is no cache, I would like the build workflow to proceed without a cache.
 
       - name: Remove LFS Pointer
         run: find src -type f \( -name '*.webp' -o -name '*.webm' -o -name '*.mp3' \) -delete
@@ -457,16 +455,21 @@ jobs:
           ls -alR book
 
       - name: Upload Pages Artifact
+        id: deployment
         uses: actions/upload-pages-artifact@v4
         with:
           path: book
 
   deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -361,7 +361,7 @@ jobs:
         with:
           path: tmp-media
           key: ${{ needs.cache-media-files.outputs.media-cache-key }}
-          fail-on-cache-miss: false # If there is no cache, I would like the build workflow to proceed without a cache.
+          fail-on-cache-miss: true
 
       - name: Remove LFS Pointer
         run: find src -type f \( -name '*.webp' -o -name '*.webm' -o -name '*.mp3' \) -delete

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -450,10 +450,6 @@ jobs:
           rm -rf FontAwesome
           rm -rf fonts
 
-      - name: List Segments
-        run: |
-          ls -alR book
-
       - name: Upload Pages Artifact
         id: deployment
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,5 +1,4 @@
-name: github-pages
-
+name: Deploy
 on:
   push:
     branches:
@@ -25,6 +24,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           lfs: false
+          fetch-depth: 0
           sparse-checkout: |
             src
 
@@ -335,18 +335,18 @@ jobs:
         run: |
           cargo test --verbose
 
-  build-and-deploy:
-    permissions:
-      contents: write
-    name: Build and Deploy
+  build:
+    name: Build
     runs-on: macos-15
-    if: ${{ github.ref == 'refs/heads/main' }}
     needs: [build-wasm, build-js, build-scss, cache-media-files, convert-woff2, test-mdbook-backend]
+    env:
+      MDBOOK_VERSION: 0.4.52
     steps:
       - name: Checkout the repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           lfs: false # Make it clear (just in case) that lfs is not used in this step.
+          fetch-depth: 0
           sparse-checkout: |
             book.toml
             rs/mdbook-footnote
@@ -394,19 +394,19 @@ jobs:
             target/
           key: backend-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Setup Backend
+      - name: Install mdbook
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
+          cargo install --version ${MDBOOK_VERSION} mdbook
           cargo install mdbook-admonish
           cargo install mdbook-tailor
           cargo install --path ./rs/mdbook-footnote
 
-      - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2
-        with:
-          mdbook-version: "0.4.52"
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
 
-      - name: Build mdBook
+      - name: Build Book
         run: |
           mdbook build
 
@@ -452,8 +452,18 @@ jobs:
         run: |
           ls -alR book
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+      - name: Upload Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: book
+          path: book
+
+      Deploy:
+        environment:
+          name: github-pages
+          url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        needs: build
+        steps:
+          - name: Deploy to GitHub Pages
+            id: deployment
+            uses: actions/deploy-pages@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -462,6 +462,7 @@ jobs:
 
   deploy:
     name: Deploy
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     needs: build
     permissions:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -457,13 +457,13 @@ jobs:
         with:
           path: book
 
-      Deploy:
-        environment:
-          name: github-pages
-          url: ${{ steps.deployment.outputs.page_url }}
-        runs-on: ubuntu-latest
-        needs: build
-        steps:
-          - name: Deploy to GitHub Pages
-            id: deployment
-            uses: actions/deploy-pages@v4
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,7 +5,10 @@ on:
       - main
   pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -403,6 +406,7 @@ jobs:
           cargo install --path ./rs/mdbook-footnote
 
       - name: Setup Pages
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         id: pages
         uses: actions/configure-pages@v5
 
@@ -452,8 +456,8 @@ jobs:
         run: |
           ls -alR book
 
-      - name: Upload Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
         with:
           path: book
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Check if cache is exact match
         id: check-cache
         run: |
-             if [ "${{ steps.cache-source.outputs.cache-hit }}" = "true" ] && \
+          if [ "${{ steps.cache-source.outputs.cache-hit }}" = "true" ] && \
              [ "${{ steps.cache-source.outputs.cache-matched-key }}" = "${{ steps.set-cache-key.outputs.cache-key }}" ]; then
             echo "exact=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,6 +16,7 @@ jobs:
   cache-media-files:
     name: Cache Media Files
     runs-on: macos-15
+    if: ${{ github.ref == 'refs/heads/main' }}
     outputs:
       media-cache-key: ${{ steps.set-cache-key.outputs.cache-key }}
       cache-hit-exact: ${{ steps.check-cache.outputs.exact }}
@@ -44,8 +45,7 @@ jobs:
       - name: Check if cache is exact match
         id: check-cache
         run: |
-          if [ "${GITHUB_REF}" == "refs/heads/main" ] && \
-             [ "${{ steps.cache-source.outputs.cache-hit }}" = "true" ] && \
+             if [ "${{ steps.cache-source.outputs.cache-hit }}" = "true" ] && \
              [ "${{ steps.cache-source.outputs.cache-matched-key }}" = "${{ steps.set-cache-key.outputs.cache-key }}" ]; then
             echo "exact=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -457,7 +457,7 @@ jobs:
           ls -alR book
 
       - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: book
 


### PR DESCRIPTION
Lately, I've been getting on a roll and accelerating the site bloat...

Switching to using `deploy-pages` will reduce the increase in repository size since I don't have to go through the `gh-pages` branch (or so I've heard...).

So I'll give it a try!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Migrated publishing to GitHub Pages native deploy flow with separate Build and Deploy jobs, artifact upload, and renamed workflow; pinned mdBook version and tightened workflow permissions.
- Performance
  - Compressed the search index and removed unneeded build outputs to reduce site download size.
- Reliability
  - Enabled full repository checkout, expanded included sources, added automated page-list and search-index generation, and added concurrency cancel-in-progress for safer runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->