### PR TITLE
Specify the retention days 📅

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -488,7 +488,6 @@ jobs:
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: book
-          retention-days: 1
 
   deploy:
     name: Deploy


### PR DESCRIPTION
The `artifacts` handled in this project's workflow are large in size, which is troublesome enough on its own, so there's no need to keep them for the (default) `90` days 😅

Please delete them after `1` day!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI artifact retention to 1 day for build, test, and publish steps to standardize post-run assets and reports. No functional, UI, or performance changes for end-users; no action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->