### PR TITLE
Simply use `ubuntu-latest` 🖥

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   cache-media-files:
     name: Cache Media Files
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     outputs:
       media-cache-key: ${{ steps.set-cache-key.outputs.cache-key }}
@@ -79,7 +79,7 @@ jobs:
 
   test-wasm:
     name: Test Wasm
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -112,7 +112,7 @@ jobs:
 
   build-wasm:
     name: Build Wasm
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     needs: test-wasm
     steps:
       - name: Checkout the repo
@@ -146,7 +146,8 @@ jobs:
 
       - name: Install Binaryen
         run: |
-          brew install binaryen
+          sudo apt update
+          sudo apt install -y binaryen
 
       - name: Optimization Wasm
         working-directory: rs/wasm
@@ -167,7 +168,7 @@ jobs:
 
   test-js:
     name: Test JS
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     needs: build-wasm
     steps:
       - name: Checkout the repo
@@ -220,7 +221,7 @@ jobs:
 
   build-js:
     name: Build JS
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     needs: [test-js, build-wasm]
     steps:
       - name: Checkout the repo
@@ -274,7 +275,7 @@ jobs:
 
   build-scss:
     name: Build SCSS
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -304,7 +305,7 @@ jobs:
 
   convert-woff2:
     name: Convert WOFF2
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -345,7 +346,7 @@ jobs:
 
   test-mdbook-backend:
     name: Test mdBook Backend
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -371,7 +372,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     needs: [build-wasm, build-js, build-scss, cache-media-files, convert-woff2, test-mdbook-backend]
     env:
       MDBOOK_VERSION: 0.4.52


### PR DESCRIPTION
>I honestly didn't think it would make much difference, but taking the most time consuming `Install Cargo` as an example, I was able to reduce it from `5m 18s` to `4m 5s`!

At the time, that's why we switched the runner to `macOS` in #87 and continued using it,
but we plan to switch the runner back to Ubuntu with this PR.

This might be the cause of recent errors occurring with `renovate` (#564, etc.),
so let's see how things go with this change.