### PR TITLE
Enable `simd128` for WASM builds 🧬

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -133,6 +133,10 @@ jobs:
             target/
           key: wasm-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Add wasm target
+        run: |
+          rustup target add wasm32-unknown-unknown
+
       - name: Install Cargo
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -137,12 +137,17 @@ jobs:
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
           cargo install wasm-bindgen-cli
-          cargo install wasm-pack
 
       - name: Build Wasm
         working-directory: rs/wasm
         run: |
-          wasm-pack build --target web
+          RUSTFLAGS="-C target-feature=+simd128" \
+            cargo build --release --target wasm32-unknown-unknown
+
+          wasm-bindgen \
+            ./target/wasm32-unknown-unknown/release/wasm_book.wasm \
+            --target web \
+            --out-dir pkg
 
       - name: Enable Homebrew
         run: |
@@ -155,13 +160,6 @@ jobs:
       - name: Optimization Wasm
         working-directory: rs/wasm
         run: |
-          RUSTFLAGS="-C target-feature=+simd128" \
-            cargo build --release --target wasm32-unknown-unknown
-
-          wasm-bindgen target/wasm32-unknown-unknown/release/wasm_book.wasm \
-            --target web \
-            --out-dir pkg
-
           wasm-opt ./pkg/wasm_book_bg.wasm \
             -O \
             --enable-simd \
@@ -170,6 +168,9 @@ jobs:
             --strip-debug \
             --strip-producers \
             --strip-dwarf \
+            -o ./pkg/wasm_book_bg.opt.wasm
+
+            mv ./pkg/wasm_book_bg.opt.wasm ./pkg/wasm_book_bg.wasm
 
       - name: Upload wasm_pkg
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -155,14 +155,21 @@ jobs:
       - name: Optimization Wasm
         working-directory: rs/wasm
         run: |
+          RUSTFLAGS="-C target-feature=+simd128" \
+            cargo build --release --target wasm32-unknown-unknown
+
+          wasm-bindgen target/wasm32-unknown-unknown/release/wasm_book.wasm \
+            --target web \
+            --out-dir pkg
+
           wasm-opt ./pkg/wasm_book_bg.wasm \
             -O \
+            --enable-simd \
             --enable-nontrapping-float-to-int \
             --enable-bulk-memory \
             --strip-debug \
             --strip-producers \
             --strip-dwarf \
-            -o ./pkg/wasm_book_bg.wasm
 
       - name: Upload wasm_pkg
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ js/coverage
 js/dist
 js/highlight.js
 js/wasm_book.js
-js/wasm_book.d.ts
 
 rs/mdbook-footnote/test/result.md
 
@@ -20,6 +19,7 @@ scss/dist
 
 *.tmp
 *.wasm
+*.d.ts
 
 src/*.js
 src/css

--- a/debug.sh
+++ b/debug.sh
@@ -1,18 +1,27 @@
 set -eu
 
 pushd rs/wasm
-wasm-pack build --target web
+
+RUSTFLAGS="-C target-feature=+simd128" \
+  cargo build --release --target wasm32-unknown-unknown
+
+wasm-bindgen ./target/wasm32-unknown-unknown/release/wasm_book.wasm \
+  --target web \
+  --out-dir pkg
+
 wasm-opt ./pkg/wasm_book_bg.wasm \
   -O \
+  --enable-simd \
   --enable-nontrapping-float-to-int \
   --enable-bulk-memory \
   --strip-debug \
   --strip-producers \
   --strip-dwarf \
-  -o ./pkg/wasm_book_bg.wasm
+
 cp pkg/wasm_book.js ../../js
 cp pkg/wasm_book.d.ts ../../js
 cp pkg/wasm_book_bg.wasm ../../src
+
 popd
 
 pushd js

--- a/debug.sh
+++ b/debug.sh
@@ -5,7 +5,8 @@ pushd rs/wasm
 RUSTFLAGS="-C target-feature=+simd128" \
   cargo build --release --target wasm32-unknown-unknown
 
-wasm-bindgen ./target/wasm32-unknown-unknown/release/wasm_book.wasm \
+wasm-bindgen \
+  ./target/wasm32-unknown-unknown/release/wasm_book.wasm \
   --target web \
   --out-dir pkg
 
@@ -17,6 +18,9 @@ wasm-opt ./pkg/wasm_book_bg.wasm \
   --strip-debug \
   --strip-producers \
   --strip-dwarf \
+  -o ./pkg/wasm_book_bg.opt.wasm
+
+mv ./pkg/wasm_book_bg.opt.wasm ./pkg/wasm_book_bg.wasm
 
 cp pkg/wasm_book.js ../../js
 cp pkg/wasm_book.d.ts ../../js


### PR DESCRIPTION
This PR enables SIMD (simd128) support for the WebAssembly build and improves compatibility across the WASM toolchain (`wasm-bindgen` and `wasm-opt`).

The changes are as follows.

- Enable `simd128` via `RUSTFLAGS` for WASM target
- Update `wasm-opt` configuration to support SIMD (`--enable-simd`)

I’ve confirmed that the optimized output generated by `wasm2wat` includes `v128.*` instructions.

In theory, this should improve the performance of text-processing workloads (which make heavy use of `memchr`)❗

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved WebAssembly build and CI workflow for faster, more efficient builds and platform-specific SIMD optimizations.
  * Updated ignore rules to exclude generated JavaScript and TypeScript declaration files from source control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoralPink/commentary/pull/740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->