### PR TITLE
Reducing WASM build time ⏰

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -138,6 +138,7 @@ jobs:
           curl -L https://github.com/WebAssembly/binaryen/releases/download/version_129/binaryen-version_129-x86_64-linux.tar.gz.sha256 -o binaryen.sha256
           echo "$(cut -d' ' -f1 binaryen.sha256)  binaryen.tar.gz" | sha256sum -c -
 
+          tar xzf binaryen.tar.gz
           echo "$PWD/binaryen-version_129/bin" >> $GITHUB_PATH
 
       - name: Optimization Wasm

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -87,23 +87,14 @@ jobs:
           sparse-checkout: |
             rs/wasm
 
-      - name: Cache Cargo
-        id: cache-cargo
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: wasm-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          toolchain: stable
+          target: wasm32-unknown-unknown
 
-      - name: Install Cargo
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
-        run: |
-          cargo install wasm-bindgen-cli
-          cargo install wasm-pack
+      - uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a #v2
+        with:
+          tool: wasm-pack
 
       - name: Test Wasm
         working-directory: rs/wasm
@@ -121,26 +112,14 @@ jobs:
           sparse-checkout: |
             rs/wasm
 
-      - name: Cache Cargo
-        id: cache-cargo
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: wasm-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          toolchain: stable
+          target: wasm32-unknown-unknown
 
-      - name: Add wasm target
-        run: |
-          rustup target add wasm32-unknown-unknown
-
-      - name: Install Cargo
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
-        run: |
-          cargo install wasm-bindgen-cli
+      - uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a #v2
+        with:
+          tool: wasm-bindgen-cli,binaryen
 
       - name: Build Wasm
         working-directory: rs/wasm
@@ -152,14 +131,6 @@ jobs:
             ./target/wasm32-unknown-unknown/release/wasm_book.wasm \
             --target web \
             --out-dir pkg
-
-      - name: Enable Homebrew
-        run: |
-          echo "PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH" >> $GITHUB_ENV
-
-      - name: Install binaryen
-        run: |
-          brew install binaryen
 
       - name: Optimization Wasm
         working-directory: rs/wasm

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -57,6 +57,7 @@ jobs:
         if: steps.check-cache.outputs.exact != 'true'
         run: |
           git lfs pull --include="src/**/*.webp,src/**/*.webm,src/**/*.mp3"
+
       - name: Synchronize Media Files
         if: steps.check-cache.outputs.exact != 'true'
         run: |
@@ -87,12 +88,14 @@ jobs:
           sparse-checkout: |
             rs/wasm
 
-      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
 
-      - uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a #v2
+      - name: Install Wasm Pack
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a #v2
         with:
           tool: wasm-pack
 
@@ -112,12 +115,14 @@ jobs:
           sparse-checkout: |
             rs/wasm
 
-      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
 
-      - uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a #v2
+      - name: Install Wasm Bindgen
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a #v2
         with:
           tool: wasm-bindgen-cli@0.2.122
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -87,7 +87,7 @@ jobs:
           sparse-checkout: |
             rs/wasm
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
@@ -119,7 +119,7 @@ jobs:
 
       - uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a #v2
         with:
-          tool: wasm-bindgen-cli,binaryen
+          tool: wasm-bindgen-cli
 
       - name: Build Wasm
         working-directory: rs/wasm
@@ -131,6 +131,12 @@ jobs:
             ./target/wasm32-unknown-unknown/release/wasm_book.wasm \
             --target web \
             --out-dir pkg
+
+      - name: Install Binaryen
+        run: |
+          curl -L https://github.com/WebAssembly/binaryen/releases/latest/download/binaryen-version_129-x86_64-linux.tar.gz \
+            | tar xz
+          echo "$PWD/binaryen-version_129/bin" >> $GITHUB_PATH
 
       - name: Optimization Wasm
         working-directory: rs/wasm

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -119,7 +119,7 @@ jobs:
 
       - uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a #v2
         with:
-          tool: wasm-bindgen-cli
+          tool: wasm-bindgen-cli@0.2.122
 
       - name: Build Wasm
         working-directory: rs/wasm
@@ -134,8 +134,10 @@ jobs:
 
       - name: Install Binaryen
         run: |
-          curl -L https://github.com/WebAssembly/binaryen/releases/latest/download/binaryen-version_129-x86_64-linux.tar.gz \
-            | tar xz
+          curl -L https://github.com/WebAssembly/binaryen/releases/download/version_129/binaryen-version_129-x86_64-linux.tar.gz -o binaryen.tar.gz
+          curl -L https://github.com/WebAssembly/binaryen/releases/download/version_129/binaryen-version_129-x86_64-linux.tar.gz.sha256 -o binaryen.sha256
+          echo "$(cut -d' ' -f1 binaryen.sha256)  binaryen.tar.gz" | sha256sum -c -
+
           echo "$PWD/binaryen-version_129/bin" >> $GITHUB_PATH
 
       - name: Optimization Wasm


### PR DESCRIPTION
When it comes to building WASM (Rust),
it seems that using  [`setup-rust-toolchain`](https://github.com/actions-rust-lang/setup-rust-toolchain) and [`install-action`](https://github.com/taiki-e/install-action) is more efficient in many ways.

Let's give it a try! 😆

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow: switched to dedicated toolchain/setup and install helpers, simplified install and caching steps, and replaced package-manager installation of the wasm optimizer with a verified direct download.
  * No user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoralPink/commentary/pull/741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->