### PR TITLE
Try `Ubuntu Slim` 🫍

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   check-diff:
     name: Check Differences
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       changes: ${{ steps.filter.outputs.source }}
     steps:
@@ -42,7 +42,7 @@ jobs:
 
   cache-media-files:
     name: Cache Media Files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ github.ref == 'refs/heads/main' }}
     outputs:
       media-cache-key: ${{ steps.set-cache-key.outputs.cache-key }}
@@ -136,7 +136,7 @@ jobs:
 
   build-wasm:
     name: Build Wasm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: test-wasm
     env:
       BINARYEN_VERSION: "130"
@@ -204,7 +204,7 @@ jobs:
 
   test-js:
     name: Test JS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: build-wasm
     steps:
       - name: Checkout the repo
@@ -247,7 +247,7 @@ jobs:
 
   build-js:
     name: Build JS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [test-js, build-wasm]
     steps:
       - name: Checkout the repo
@@ -295,7 +295,7 @@ jobs:
 
   build-scss:
     name: Build SCSS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -331,7 +331,7 @@ jobs:
 
   convert-woff2:
     name: Convert WOFF2
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -374,7 +374,7 @@ jobs:
 
   test-mdbook-backend:
     name: Test mdBook Backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -383,6 +383,11 @@ jobs:
           fetch-depth: 1
           sparse-checkout: |
             rs/mdbook-footnote
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          toolchain: stable
 
       - name: Cache Cargo
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -460,6 +465,11 @@ jobs:
           cp -r artifacts/woff2 src
           cp -r artifacts/css src
           cp -r tmp src
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          toolchain: stable
 
       - name: Cache Cargo
         id: cache-cargo
@@ -545,7 +555,7 @@ jobs:
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
       needs.check-diff.outputs.changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs:
       - check-diff
       - publish

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -136,7 +136,7 @@ jobs:
 
   build-wasm:
     name: Build Wasm
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     needs: test-wasm
     env:
       BINARYEN_VERSION: "130"
@@ -374,7 +374,7 @@ jobs:
 
   test-mdbook-backend:
     name: Test mdBook Backend
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
It’s exactly as the title says.
Let's give it a try!

Some jobs still use `ubuntu-latest` because they require `brotli` or `chrome`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to use a slimmer runner for faster, more efficient site builds and tests.
  * Added Rust toolchain initialization for the documentation/backend build steps to ensure reliable docs compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->