### PR TITLE
Try `Ubuntu Arm64` 🦈

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -108,7 +108,7 @@ jobs:
 
   test-wasm:
     name: Test Wasm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout the repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -132,11 +132,11 @@ jobs:
       - name: Test Wasm
         working-directory: rs/wasm
         run: |
-          wasm-pack test --headless --chrome
+          wasm-pack test --headless --firefox
 
   build-wasm:
     name: Build Wasm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: test-wasm
     env:
       BINARYEN_VERSION: "130"
@@ -374,7 +374,7 @@ jobs:
 
   test-mdbook-backend:
     name: Test mdBook Backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout the repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -411,7 +411,7 @@ jobs:
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
       needs.check-diff.outputs.changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs:
       - build-wasm
       - build-js

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -393,12 +393,11 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: test-backend-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: test-backend-${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Test Cargo (mdbook-footnote)
         working-directory: rs/mdbook-footnote
@@ -476,12 +475,11 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: backend-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: test-backend-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install mdbook
         if: steps.cache-cargo.outputs.cache-hit != 'true'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -172,8 +172,8 @@ jobs:
 
       - name: Install Binaryen
         run: |
-          curl -L https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz -o binaryen.tar.gz
-          curl -L https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz.sha256 -o binaryen.sha256
+          curl -L https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-aarch64-linux.tar.gz -o binaryen.tar.gz
+          curl -L https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-aarch64-linux.tar.gz.sha256 -o binaryen.sha256
           echo "$(cut -d' ' -f1 binaryen.sha256)  binaryen.tar.gz" | sha256sum -c -
 
           tar xzf binaryen.tar.gz

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -479,12 +479,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: test-backend-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: publish-${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install mdbook
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
-          cargo install --version ${MDBOOK_VERSION} mdbook
+          cargo install mdbook --version ${MDBOOK_VERSION}
 
           #cargo install mdbook-admonish
           git clone https://github.com/CoralPink/mdbook-admonish.git -b mdbook-v0.5.x --depth 1 || exit 1


### PR DESCRIPTION
Following up on #754, I’d like you to give `Ubuntu Arm64` a try as well.
If this works out, my workflow will become a hybrid of `slim` and `arm64`—which sounds like a lot of fun!! 😆

After checking [Release Note](https://github.com/actions/runner-images/releases/tag/ubuntu24-arm64%2F20260531.15),
it appears that the runner image does not include `Chrome`, so I will switch to using `Firefox` for the `wasm-pack test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to run on ARM Linux runners instead of the previous default.
  * WebAssembly tests now run in Firefox for browser-based checks.
  * Build artifacts and cache paths/formats adjusted for the ARM build environment.
  * Release workflow now always installs the specified mdBook version instead of relying on a cache hit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->