### PR TITLE
Revisiting the Rust Build Workflow 🐋

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -123,6 +123,7 @@ jobs:
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
+          cache-workspaces: rs/wasm
 
       - name: Install Wasm Pack
         uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2
@@ -154,6 +155,7 @@ jobs:
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
+          cache-workspaces: rs/wasm
 
       - name: Install Wasm Bindgen
         uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2
@@ -388,16 +390,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           toolchain: stable
-
-      - name: Cache Cargo
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: test-backend-${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache-workspaces: rs/mdbook-footnote
 
       - name: Test Cargo (mdbook footnote)
         working-directory: rs/mdbook-footnote
@@ -470,27 +463,15 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Cache Cargo
-        id: cache-cargo
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: publish-${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Install Mdbook
         run: |
-          cargo install mdbook --version ${MDBOOK_VERSION}
+          cargo +stable install mdbook --version ${MDBOOK_VERSION}
 
-          #cargo install mdbook-admonish
-          git clone https://github.com/CoralPink/mdbook-admonish.git -b mdbook-v0.5.x --depth 1 || exit 1
-          cargo install --path ./mdbook-admonish
+          #cargo +stable install mdbook-admonish
+          cargo +stable install --git https://github.com/CoralPink/mdbook-admonish.git --branch mdbook-v0.5.x
 
-          cargo install mdbook-tailor
-          cargo install --path ./rs/mdbook-footnote
+          cargo +stable install mdbook-tailor
+          cargo +stable install --path ./rs/mdbook-footnote
 
       - name: Setup Pages
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  WASM_SHARED_KEY: wasm-rs-v1
+
 jobs:
   check-diff:
     name: Check Differences
@@ -124,6 +127,7 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
           cache-workspaces: rs/wasm
+          cache-shared-key: ${{ env.WASM_SHARED_KEY }}
 
       - name: Install Wasm Pack
         uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2
@@ -156,6 +160,7 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
           cache-workspaces: rs/wasm
+          cache-shared-key: ${{ env.WASM_SHARED_KEY }}
 
       - name: Install Wasm Bindgen
         uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2


### PR DESCRIPTION
In our current workflow, there are several areas where the `Rust` build and caching processes aren't working as intended.

This PR makes the following changes:

- Change the configuration so that all cache processing is handled by `setup-rust-toolchain`.
- Explicitly specify `+stable` with `cargo install` (To suppress warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI caching configuration to speed and stabilize Rust-related build and test jobs.
  * Switched documentation tool installation to pinned, direct package installs for more reliable builds.
  * Removed redundant publish/cache steps to streamline the release workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->