### PR TITLE
debug(wasm): Is SIMD disabled...?

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -171,6 +171,7 @@ jobs:
         run: |
           ls -R .
           cat .cargo/config.toml || echo "NO CONFIG"
+          cat rs/wasm/.cargo/config.toml || echo "NO CONFIG"
 
       - name: Build Wasm
         working-directory: rs/wasm

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -175,7 +175,7 @@ jobs:
         working-directory: rs/wasm
         run: |
           RUSTFLAGS="-C target-feature=+simd128" \
-            cargo -vv build --release --target wasm32-unknown-unknown
+            cargo build --release --target wasm32-unknown-unknown
 
           wasm-bindgen \
             ./target/wasm32-unknown-unknown/release/wasm_book.wasm \

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -167,6 +167,11 @@ jobs:
         with:
           tool: wasm-bindgen-cli@0.2.125
 
+      - name: debug cargo config
+        run: |
+          ls -R .
+          cat .cargo/config.toml || echo "NO CONFIG"
+
       - name: Build Wasm
         working-directory: rs/wasm
         run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -174,8 +174,8 @@ jobs:
       - name: Build Wasm
         working-directory: rs/wasm
         run: |
-          #cargo build --release --target wasm32-unknown-unknown
-          cargo -vv build --release --target wasm32-unknown-unknown
+          RUSTFLAGS="-C target-feature=+simd128" \
+            cargo -vv build --release --target wasm32-unknown-unknown
 
           wasm-bindgen \
             ./target/wasm32-unknown-unknown/release/wasm_book.wasm \

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -169,14 +169,13 @@ jobs:
 
       - name: debug cargo config
         run: |
-          ls -R .
-          cat .cargo/config.toml || echo "NO CONFIG"
           cat rs/wasm/.cargo/config.toml || echo "NO CONFIG"
 
       - name: Build Wasm
         working-directory: rs/wasm
         run: |
-          cargo build --release --target wasm32-unknown-unknown
+          #cargo build --release --target wasm32-unknown-unknown
+          cargo -vv build --release --target wasm32-unknown-unknown
 
           wasm-bindgen \
             ./target/wasm32-unknown-unknown/release/wasm_book.wasm \


### PR DESCRIPTION
I can confirm that the WASM file generated locally contains SIMD instructions, but I can't find them in the WASM file generated by CI...

This PR is intended to investigate the cause of this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced build pipeline diagnostics to surface workspace and configuration visibility during builds, aiding troubleshooting and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->