### PR TITLE
You and I must make a pact 🧒🏾

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,17 @@
   "labels": [
     "dependencies"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "^\\.github/workflows/.*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\w+:\\s*\"(?<currentValue>[^\"]+)\""
+      ]
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": ["taiki-e/install-action"],

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -144,6 +144,9 @@ jobs:
     runs-on: ubuntu-26.04-arm
     needs: test-wasm
     env:
+      # renovate: datasource=cargo depName=wasm-bindgen
+      WASM_BINDGEN_VERSION: "0.2.126"
+      # renovate: datasource=github-releases depName=WebAssembly/binaryen
       BINARYEN_VERSION: "130"
     steps:
       - name: Checkout Repository
@@ -165,7 +168,7 @@ jobs:
       - name: Install Wasm Bindgen
         uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2
         with:
-          tool: wasm-bindgen-cli@0.2.125
+          tool: wasm-bindgen-cli@${{ env.WASM_BINDGEN_VERSION }}
 
       - name: Build Wasm
         working-directory: rs/wasm
@@ -414,6 +417,7 @@ jobs:
       - convert-woff2
       - test-mdbook-backend
     env:
+      # renovate: datasource=cargo depName=mdbook
       MDBOOK_VERSION: "0.5.3"
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
In #785, I accidentally forgot to update `wasm-bindgen-cli`.
Since it’s clear I’ll keep making the same mistake, I want to delegate this task to `renovatebot`.

It seems you can do that by using `customManagers`—give it a try!

While we're at it, let's apply this to `binaryen` and `mdbook` as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation settings to detect version hints in workflow files.
  * Added version-tracking comments in release workflows so key tools can be updated more easily.
  * Bumped a build tool version used for WebAssembly publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->