### PR TITLE
More Active Use of the `Popover API` and Site Refactoring 🍿

### DIFF
--- a/js/deno.jsonc
+++ b/js/deno.jsonc
@@ -5,7 +5,7 @@
 
     "vitest": "npm:vitest@4.1.10",
     "@vitest/coverage-v8": "npm:@vitest/coverage-v8@4.1.10",
-    "happy-dom": "npm:happy-dom@20.10.6"
+    "happy-dom": "npm:happy-dom@20.11.0"
   },
   "minimumDependencyAge": {
     "age": "PT12H",

--- a/js/extensions/footnote-legacy.ts
+++ b/js/extensions/footnote-legacy.ts
@@ -2,14 +2,16 @@ import { ROOT_PATH } from '../constants.ts';
 import type { Disposer } from './types.ts';
 
 import { loadStyleSheet } from '../utils/css-loader.ts';
-import { createEventScope } from '../utils/event-scope.ts';
+import { createAbortScope } from '../utils/abort-scope.ts';
 import { setHTML } from '../utils/html-sanitizer.ts';
 
 const FILE_STYLE_FOOTNOTE = 'css/footnote-legacy.css';
 
 const POSITION_GAP = 10;
 
-const footnoteEventScope = createEventScope();
+let activeFootnoteClose: (() => void) | null = null;
+
+const footnoteEventScope = createAbortScope();
 
 const calcTop = (target: HTMLElement, pop: HTMLElement): number => {
   const rect = target.getBoundingClientRect();
@@ -86,14 +88,28 @@ const handleFootnoteClick = (ev: Event): void => {
 
   document.body.append(pop);
 
+  activeFootnoteClose?.();
+
+  const close = () => {
+    footnoteEventScope.dispose();
+    closeFootnotePop(target, pop);
+
+    if (activeFootnoteClose === close) {
+      activeFootnoteClose = null;
+    }
+  };
+
+  activeFootnoteClose = close;
+
   requestAnimationFrame(() => {
+    if (!pop.isConnected) {
+      return;
+    }
     pop.style.top = `${calcTop(target, pop) + globalThis.scrollY}px`;
 
     target.ariaExpanded = 'true';
     target.ariaControlsElements = [pop];
   });
-
-  const signal = footnoteEventScope.begin();
 
   document.addEventListener(
     'click',
@@ -104,13 +120,11 @@ const handleFootnoteClick = (ev: Event): void => {
       if (pop.contains(ev.target) || target === ev.target) {
         return;
       }
-
-      closeFootnotePop(target, pop);
-      footnoteEventScope.dispose();
+      close();
     },
     {
       passive: true,
-      signal,
+      signal: footnoteEventScope.begin(),
     },
   );
 };
@@ -131,6 +145,6 @@ export const initialize = (html: HTMLElement): Disposer => {
 
   return () => {
     ac.abort();
-    footnoteEventScope.dispose();
+    activeFootnoteClose?.();
   };
 };

--- a/js/extensions/footnote-legacy.ts
+++ b/js/extensions/footnote-legacy.ts
@@ -2,11 +2,14 @@ import { ROOT_PATH } from '../constants.ts';
 import type { Disposer } from './types.ts';
 
 import { loadStyleSheet } from '../utils/css-loader.ts';
+import { createEventScope } from '../utils/event-scope.ts';
 import { setHTML } from '../utils/html-sanitizer.ts';
 
 const FILE_STYLE_FOOTNOTE = 'css/footnote-legacy.css';
 
 const POSITION_GAP = 10;
+
+const footnoteEventScope = createEventScope();
 
 const calcTop = (target: HTMLElement, pop: HTMLElement): number => {
   const rect = target.getBoundingClientRect();
@@ -25,17 +28,7 @@ const closeFootnotePop = (target: HTMLElement, elm: HTMLElement): void => {
   target.ariaExpanded = null;
   target.ariaControlsElements = null;
 
-  elm.addEventListener(
-    'transitionend',
-    (ev: TransitionEvent) => {
-      if (ev.propertyName === 'opacity') {
-        elm.remove();
-      }
-    },
-    { once: true, passive: true },
-  );
-
-  elm.classList.remove('show');
+  elm.remove();
 };
 
 const insertFootnote = (pop: HTMLElement): void => {
@@ -75,18 +68,9 @@ const handleFootnoteClick = (ev: Event): void => {
     return;
   }
 
-  target.ariaExpanded = 'true';
-
-  const popover = document.getElementById(popIdStr);
-
-  if (popover !== null) {
-    target.ariaControlsElements = [popover];
-  }
-
   const pop = document.createElement('aside');
 
   pop.classList.add('ft-pop');
-  pop.style.top = `${calcTop(target, pop) + globalThis.scrollY}px`;
   pop.role = 'tooltip';
   pop.id = popIdStr;
 
@@ -100,13 +84,16 @@ const handleFootnoteClick = (ev: Event): void => {
   setHTML(pop, footnote.innerHTML);
   insertFootnote(pop);
 
-  requestAnimationFrame(() => {
-    pop.classList.add('show');
-  });
-
   document.body.append(pop);
 
-  const ac = new AbortController();
+  requestAnimationFrame(() => {
+    pop.style.top = `${calcTop(target, pop) + globalThis.scrollY}px`;
+
+    target.ariaExpanded = 'true';
+    target.ariaControlsElements = [pop];
+  });
+
+  const signal = footnoteEventScope.begin();
 
   document.addEventListener(
     'click',
@@ -119,11 +106,11 @@ const handleFootnoteClick = (ev: Event): void => {
       }
 
       closeFootnotePop(target, pop);
-      ac.abort();
+      footnoteEventScope.dispose();
     },
     {
       passive: true,
-      signal: ac.signal,
+      signal,
     },
   );
 };
@@ -144,5 +131,6 @@ export const initialize = (html: HTMLElement): Disposer => {
 
   return () => {
     ac.abort();
+    footnoteEventScope.dispose();
   };
 };

--- a/js/extensions/footnote-legacy.ts
+++ b/js/extensions/footnote-legacy.ts
@@ -1,0 +1,153 @@
+import { ROOT_PATH } from '../constants.ts';
+import type { Disposer } from './types.ts';
+
+import { loadStyleSheet } from '../utils/css-loader.ts';
+import { setHTML } from '../utils/html-sanitizer.ts';
+
+const FILE_STYLE_FOOTNOTE = 'css/footnote-legacy.css';
+
+const POSITION_GAP = 10;
+
+const calcTop = (target: HTMLElement, pop: HTMLElement): number => {
+  const rect = target.getBoundingClientRect();
+  const popHeight = pop.offsetHeight;
+
+  const top = rect.bottom + POSITION_GAP;
+
+  // Flip above if overflowing viewport bottom
+  if (top + popHeight > globalThis.innerHeight - POSITION_GAP) {
+    return rect.top - popHeight - POSITION_GAP;
+  }
+  return top;
+};
+
+const closeFootnotePop = (target: HTMLElement, elm: HTMLElement): void => {
+  target.ariaExpanded = null;
+  target.ariaControlsElements = null;
+
+  elm.addEventListener(
+    'transitionend',
+    (ev: TransitionEvent) => {
+      if (ev.propertyName === 'opacity') {
+        elm.remove();
+      }
+    },
+    { once: true, passive: true },
+  );
+
+  elm.classList.remove('show');
+};
+
+const insertFootnote = (pop: HTMLElement): void => {
+  const sup = pop.querySelector<HTMLAnchorElement>('p > sup a[href^="#to-ft-"]');
+
+  if (!sup) {
+    return;
+  }
+
+  const oldHref = sup.getAttribute('href');
+
+  if (!oldHref) {
+    return;
+  }
+
+  sup.href = oldHref.replace(/^#to-ft-/, '#ft-');
+};
+
+const handleFootnoteClick = (ev: Event): void => {
+  const target = ev.target;
+
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  const href = target.getAttribute('data-href');
+
+  if (!href) {
+    return;
+  }
+
+  const ftId = href.slice(1);
+  const popIdStr = `popover-${ftId}`;
+
+  // If this pop is already open, do nothing
+  if (document.getElementById(popIdStr)) {
+    return;
+  }
+
+  target.ariaExpanded = 'true';
+
+  const popover = document.getElementById(popIdStr);
+
+  if (popover !== null) {
+    target.ariaControlsElements = [popover];
+  }
+
+  const pop = document.createElement('aside');
+
+  pop.classList.add('ft-pop');
+  pop.style.top = `${calcTop(target, pop) + globalThis.scrollY}px`;
+  pop.role = 'tooltip';
+  pop.id = popIdStr;
+
+  const footnote = document.getElementById(ftId);
+
+  if (footnote === null) {
+    console.error(`footnote for ${ftId} does not exist.`);
+    return;
+  }
+
+  setHTML(pop, footnote.innerHTML);
+  insertFootnote(pop);
+
+  requestAnimationFrame(() => {
+    pop.classList.add('show');
+  });
+
+  document.body.append(pop);
+
+  const ac = new AbortController();
+
+  document.addEventListener(
+    'click',
+    (ev: PointerEvent) => {
+      if (!(ev.target instanceof Node)) {
+        return;
+      }
+      if (pop.contains(ev.target) || target === ev.target) {
+        return;
+      }
+
+      closeFootnotePop(target, pop);
+      ac.abort();
+    },
+    {
+      passive: true,
+      signal: ac.signal,
+    },
+  );
+};
+
+const loadStyle = async (): Promise<void> => await loadStyleSheet(`${ROOT_PATH}${FILE_STYLE_FOOTNOTE}`);
+
+export const initialize = (html: HTMLElement): Disposer => {
+  try {
+    loadStyle();
+  } catch (err: unknown) {
+    console.error('Failed to load Footnote Style...');
+    throw err;
+  }
+
+  const ac = new AbortController();
+
+  for (const x of Array.from(html.querySelectorAll('sup.ft-reference'))) {
+    x.addEventListener('click', handleFootnoteClick, {
+      passive: true,
+      signal: ac.signal,
+    });
+  }
+
+  return () => {
+    ac.abort();
+  };
+};

--- a/js/extensions/footnote-legacy.ts
+++ b/js/extensions/footnote-legacy.ts
@@ -128,15 +128,10 @@ const handleFootnoteClick = (ev: Event): void => {
   );
 };
 
-const loadStyle = async (): Promise<void> => await loadStyleSheet(`${ROOT_PATH}${FILE_STYLE_FOOTNOTE}`);
-
 export const initialize = (html: HTMLElement): Disposer => {
-  try {
-    loadStyle();
-  } catch (err: unknown) {
-    console.error('Failed to load Footnote Style...');
-    throw err;
-  }
+  void loadStyleSheet(`${ROOT_PATH}${FILE_STYLE_FOOTNOTE}`).catch((err: unknown) => {
+    console.error('Failed to load Footnote Style...', err);
+  });
 
   const ac = new AbortController();
 

--- a/js/extensions/footnote.ts
+++ b/js/extensions/footnote.ts
@@ -2,126 +2,88 @@ import type { Disposer } from './types.ts';
 
 import { setHTML } from '../utils/html-sanitizer.ts';
 
-const POSITION_GAP = 10;
+const getAnchorName = (id: string): string => `--footnote-anchor-${id}`;
 
-const calcTop = (target: HTMLElement, pop: HTMLElement): number => {
-  const rect = target.getBoundingClientRect();
-  const popHeight = pop.offsetHeight;
+const getFootnoteId = (button: HTMLButtonElement): string | null => {
+  const href = button.dataset['href'];
 
-  const top = rect.bottom + POSITION_GAP;
-
-  // Flip above if overflowing viewport bottom
-  if (top + popHeight > globalThis.innerHeight - POSITION_GAP) {
-    return rect.top - popHeight - POSITION_GAP;
+  if (href === undefined) {
+    return null;
   }
-  return top;
-};
 
-const closeFootnotePop = (target: HTMLElement, elm: HTMLElement): void => {
-  target.ariaExpanded = null;
-  target.ariaControlsElements = null;
-
-  elm.addEventListener(
-    'transitionend',
-    (ev: TransitionEvent) => {
-      if (ev.propertyName === 'opacity') {
-        elm.remove();
-      }
-    },
-    { once: true, passive: true },
-  );
-
-  elm.classList.remove('show');
+  return href.slice(1);
 };
 
 const insertFootnote = (pop: HTMLElement): void => {
-  const sup = pop.querySelector<HTMLAnchorElement>('p > sup a[href^="#to-ft-"]');
+  const link = pop.querySelector<HTMLAnchorElement>('a[href^="#to-ft-"]');
 
-  if (!sup) {
+  if (link === null) {
     return;
   }
 
-  const oldHref = sup.getAttribute('href');
+  link.hash = link.hash.replace(/^#to-ft-/, '#ft-');
+};
 
-  if (!oldHref) {
-    return;
+const createPopoverElement = (id: string): HTMLElement => {
+  const el = document.createElement('aside');
+
+  el.popover = 'auto';
+  el.className = 'ft-pop';
+  el.role = 'dialog';
+  el.style.positionAnchor = getAnchorName(id);
+
+  const footnote = document.getElementById(id);
+
+  if (footnote === null) {
+    throw new Error(`footnote for ${id} does not exist.`);
   }
 
-  sup.href = oldHref.replace(/^#to-ft-/, '#ft-');
+  setHTML(el, footnote.innerHTML);
+  insertFootnote(el);
+
+  return el;
+};
+
+const createPopover = (button: HTMLButtonElement): void => {
+  const id = getFootnoteId(button);
+
+  if (id === null) {
+    throw new Error('missing footnote ID.');
+  }
+
+  const pop = createPopoverElement(id);
+
+  button.ariaExpanded = 'true';
+  button.style.anchorName = getAnchorName(id);
+  button.ariaControlsElements = [pop];
+
+  pop.addEventListener(
+    'toggle',
+    (ev: ToggleEvent) => {
+      if (ev.newState !== 'closed') {
+        return;
+      }
+
+      button.ariaExpanded = 'false';
+      button.ariaControlsElements = null;
+
+      pop.remove();
+    },
+    { passive: true },
+  );
+
+  document.body.append(pop);
+  pop.showPopover();
 };
 
 const handleFootnoteClick = (ev: Event): void => {
-  const target = ev.target;
+  const button = ev.target;
 
-  if (!(target instanceof HTMLElement)) {
+  if (!(button instanceof HTMLButtonElement)) {
     return;
   }
 
-  const href = target.getAttribute('data-href');
-
-  if (!href) {
-    return;
-  }
-
-  const ftId = href.slice(1);
-  const popIdStr = `popover-${ftId}`;
-
-  // If this pop is already open, do nothing
-  if (document.getElementById(popIdStr)) {
-    return;
-  }
-
-  target.ariaExpanded = 'true';
-
-  const popover = document.getElementById(popIdStr);
-
-  if (popover !== null) {
-    target.ariaControlsElements = [popover];
-  }
-
-  const pop = document.createElement('aside');
-
-  pop.classList.add('ft-pop');
-  pop.style.top = `${calcTop(target, pop) + globalThis.scrollY}px`;
-  pop.role = 'tooltip';
-  pop.id = popIdStr;
-
-  const footnote = document.getElementById(ftId);
-
-  if (footnote === null) {
-    console.error(`footnote for ${ftId} does not exist.`);
-    return;
-  }
-
-  setHTML(pop, footnote.innerHTML);
-  insertFootnote(pop);
-
-  requestAnimationFrame(() => {
-    pop.classList.add('show');
-  });
-
-  document.body.append(pop);
-
-  const ac = new AbortController();
-
-  document.addEventListener(
-    'click',
-    (ev: PointerEvent) => {
-      if (!(ev.target instanceof Node)) {
-        return;
-      }
-      if (pop.contains(ev.target) || target === ev.target) {
-        return;
-      }
-
-      closeFootnotePop(target, pop);
-      ac.abort();
-    },
-    {
-      passive: true,
-      signal: ac.signal,
-    },
-  );
+  createPopover(button);
 };
 
 export const initialize = (html: HTMLElement): Disposer => {

--- a/js/extensions/footnote.ts
+++ b/js/extensions/footnote.ts
@@ -1,6 +1,10 @@
+import { ROOT_PATH } from '../constants.ts';
 import type { Disposer } from './types.ts';
 
+import { loadStyleSheet } from '../utils/css-loader.ts';
 import { setHTML } from '../utils/html-sanitizer.ts';
+
+const FILE_STYLE_FOOTNOTE = 'css/footnote.css';
 
 const getAnchorName = (id: string): string => `--footnote-anchor-${id}`;
 
@@ -86,11 +90,19 @@ const handleFootnoteClick = (ev: Event): void => {
   createPopover(button);
 };
 
+const loadStyle = async (): Promise<void> => await loadStyleSheet(`${ROOT_PATH}${FILE_STYLE_FOOTNOTE}`);
+
 export const initialize = (html: HTMLElement): Disposer => {
-  const footnote = Array.from(html.querySelectorAll('sup.ft-reference'));
+  try {
+    loadStyle();
+  } catch (err: unknown) {
+    console.error('Failed to load Footnote Style...');
+    throw err;
+  }
+
   const ac = new AbortController();
 
-  for (const x of footnote) {
+  for (const x of Array.from(html.querySelectorAll('sup.ft-reference'))) {
     x.addEventListener('click', handleFootnoteClick, {
       passive: true,
       signal: ac.signal,

--- a/js/extensions/footnote.ts
+++ b/js/extensions/footnote.ts
@@ -90,15 +90,10 @@ const handleFootnoteClick = (ev: Event): void => {
   createPopover(button);
 };
 
-const loadStyle = async (): Promise<void> => await loadStyleSheet(`${ROOT_PATH}${FILE_STYLE_FOOTNOTE}`);
-
 export const initialize = (html: HTMLElement): Disposer => {
-  try {
-    loadStyle();
-  } catch (err: unknown) {
-    console.error('Failed to load Footnote Style...');
-    throw err;
-  }
+  void loadStyleSheet(`${ROOT_PATH}${FILE_STYLE_FOOTNOTE}`).catch((err: unknown) => {
+    console.error('Failed to load Footnote Style...', err);
+  });
 
   const ac = new AbortController();
 

--- a/js/initialize.ts
+++ b/js/initialize.ts
@@ -8,14 +8,41 @@ import type { Disposer, ExtensionEntry, InitializableExtension } from './extensi
 
 import { prepareForNextCycle, scheduleJob } from './utils/pulse.ts';
 
+type ModuleName = 'codeblock' | 'footnote' | 'footnote-legacy' | 'media' | 'slider';
+type ModuleFactory = () => ModuleName;
+
+type ModuleRequirement = {
+  selector: string;
+  module: ModuleName;
+};
+
 type HtmlJob = (html: HTMLElement) => void | Promise<void>;
 
+const selectorModule = (selector: string, module: ModuleName | ModuleFactory): ModuleRequirement => ({
+  selector,
+  module: typeof module === 'function' ? module() : module,
+});
+
+const shouldUseLegacyFootnote = (): boolean => {
+  const ua = navigator.userAgent;
+
+  const isIOS = /iPhone|iPad/.test(ua) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+  const isSafariBrowser = ua.includes('Safari') && !ua.includes('Chrome');
+
+  // iOS browsers, including Firefox and Chrome, use WebKit and require the legacy implementation.
+  return isIOS || isSafariBrowser;
+};
+
+const useLegacyFootnote = shouldUseLegacyFootnote();
+const footnoteModule = (): ModuleName => (useLegacyFootnote ? 'footnote-legacy' : 'footnote');
+
 const MODULE_REQUIREMENTS = [
-  { selector: '.slider', module: 'slider' },
-  { selector: 'video', module: 'media' },
-  { selector: 'pre code:not(.language-txt)', module: 'codeblock' },
-  { selector: 'sup', module: 'footnote' },
-] as const;
+  selectorModule('.slider', 'slider'),
+  selectorModule('video', 'media'),
+  selectorModule('pre code:not(.language-txt)', 'codeblock'),
+
+  selectorModule('sup', footnoteModule),
+] satisfies readonly ModuleRequirement[];
 
 const loadedExtensions = new Map<string, ExtensionEntry>();
 const activeDisposers = new Set<Disposer>();

--- a/js/mark.ts
+++ b/js/mark.ts
@@ -31,6 +31,27 @@ const ICONS_COLOR_ACTIVE = 'var(--search-mark-bg)';
 
 const TARGET_MARK_BUTTON = 'mark-btn';
 
+const markEventScope = (() => {
+  let controller: AbortController | null = null;
+
+  const dispose = (): void => {
+    controller?.abort();
+    controller = null;
+  };
+
+  const begin = (): AbortSignal => {
+    dispose();
+
+    controller = new AbortController();
+    return controller.signal;
+  };
+
+  return {
+    begin,
+    dispose,
+  };
+})();
+
 // Fail Fast
 const markButton = document.getElementById(TARGET_MARK_BUTTON);
 if (markButton === null) {
@@ -81,44 +102,41 @@ export const unmarking = (): void => {
 
   markButton.ariaPressed = 'false';
 
-  markButton.removeEventListener('click', unmarking);
+  const signal = markEventScope.begin();
+
   markButton.addEventListener('click', updateMark, {
-    once: true,
     passive: true,
+    signal,
   });
 
-  document.removeEventListener('keyup', keyClear);
   document.addEventListener('keyup', keyVisible, {
     passive: true,
+    signal,
   });
 };
 
 const hideButton = (): void => {
+  markEventScope.dispose();
   CSS.highlights.clear();
 
   markButton.classList.add('hidden');
-
-  markButton.removeEventListener('click', unmarking);
-  markButton.removeEventListener('click', updateMark);
-
-  document.removeEventListener('keyup', keyVisible);
-  document.removeEventListener('keyup', keyClear);
 };
 
 const visibleButton = (): void => {
+  const signal = markEventScope.begin();
   setIconColor(ICONS_COLOR_ACTIVE);
 
   markButton.ariaPressed = 'true';
-
   markButton.classList.remove('hidden');
+
   markButton.addEventListener('click', unmarking, {
-    once: true,
     passive: true,
+    signal,
   });
 
-  document.removeEventListener('keyup', keyVisible);
   document.addEventListener('keyup', keyClear, {
     passive: true,
+    signal,
   });
 };
 

--- a/js/mark.ts
+++ b/js/mark.ts
@@ -1,7 +1,7 @@
 import { isSearchPopoverOpen } from './searcher.ts';
 // deno-lint-ignore no-sloppy-imports
 import initWasm, { get_match_sentences } from './wasm_book.js';
-import { createEventScope } from './utils/event-scope.ts';
+import { createAbortScope } from './utils/abort-scope.ts';
 
 type NodeOffset = {
   text: Text;
@@ -32,7 +32,7 @@ const ICONS_COLOR_ACTIVE = 'var(--search-mark-bg)';
 
 const TARGET_MARK_BUTTON = 'mark-btn';
 
-const markEventScope = createEventScope();
+const markEventScope = createAbortScope();
 
 export const updateMark = (): void => {
   const article = document.getElementById('article');

--- a/js/mark.ts
+++ b/js/mark.ts
@@ -29,6 +29,14 @@ const TARGET_MARKING = 'marking';
 const ICONS_COLOR = 'var(--icons)';
 const ICONS_COLOR_ACTIVE = 'var(--search-mark-bg)';
 
+const TARGET_MARK_BUTTON = 'mark-btn';
+
+// Fail Fast
+const markButton = document.getElementById(TARGET_MARK_BUTTON);
+if (markButton === null) {
+  throw new Error('Missing Mark Button');
+}
+
 export const updateMark = (): void => {
   const article = document.getElementById('article');
 
@@ -62,18 +70,22 @@ const keyClear = (ev: KeyboardEvent): void => {
   }
 };
 
+const setIconColor = (color: string): void => {
+  const icon = markButton.querySelector(QUERY_MARKER) as HTMLDivElement;
+  icon.style.backgroundColor = color;
+};
+
 export const unmarking = (): void => {
   CSS.highlights.clear();
+  setIconColor(ICONS_COLOR);
 
-  for (const x of Array.from(document.querySelectorAll(`[data-target="${TARGET_MARKING}"]`))) {
-    const icon = x.querySelector(QUERY_MARKER) as HTMLDivElement;
-    icon.style.backgroundColor = ICONS_COLOR;
+  markButton.ariaPressed = 'false';
 
-    x.ariaPressed = 'false';
-
-    x.removeEventListener('click', unmarking);
-    x.addEventListener('click', updateMark, { once: true, passive: true });
-  }
+  markButton.removeEventListener('click', unmarking);
+  markButton.addEventListener('click', updateMark, {
+    once: true,
+    passive: true,
+  });
 
   document.removeEventListener('keyup', keyClear);
   document.addEventListener('keyup', keyVisible, {
@@ -84,27 +96,25 @@ export const unmarking = (): void => {
 const hideButton = (): void => {
   CSS.highlights.clear();
 
-  for (const x of Array.from(document.querySelectorAll(`[data-target="${TARGET_MARKING}"]`))) {
-    x.classList.add('hidden');
+  markButton.classList.add('hidden');
 
-    x.removeEventListener('click', unmarking);
-    x.removeEventListener('click', updateMark);
-  }
+  markButton.removeEventListener('click', unmarking);
+  markButton.removeEventListener('click', updateMark);
 
   document.removeEventListener('keyup', keyVisible);
   document.removeEventListener('keyup', keyClear);
 };
 
 const visibleButton = (): void => {
-  for (const x of Array.from(document.querySelectorAll(`[data-target="${TARGET_MARKING}"]`))) {
-    const icon = x.querySelector(QUERY_MARKER) as HTMLDivElement;
-    icon.style.backgroundColor = ICONS_COLOR_ACTIVE;
+  setIconColor(ICONS_COLOR_ACTIVE);
 
-    x.ariaPressed = 'true';
+  markButton.ariaPressed = 'true';
 
-    x.classList.remove('hidden');
-    x.addEventListener('click', unmarking, { once: true, passive: true });
-  }
+  markButton.classList.remove('hidden');
+  markButton.addEventListener('click', unmarking, {
+    once: true,
+    passive: true,
+  });
 
   document.removeEventListener('keyup', keyVisible);
   document.addEventListener('keyup', keyClear, {

--- a/js/mark.ts
+++ b/js/mark.ts
@@ -1,6 +1,7 @@
 import { isSearchPopoverOpen } from './searcher.ts';
 // deno-lint-ignore no-sloppy-imports
 import initWasm, { get_match_sentences } from './wasm_book.js';
+import { createEventScope } from './utils/event-scope.ts';
 
 type NodeOffset = {
   text: Text;
@@ -31,26 +32,7 @@ const ICONS_COLOR_ACTIVE = 'var(--search-mark-bg)';
 
 const TARGET_MARK_BUTTON = 'mark-btn';
 
-const markEventScope = (() => {
-  let controller: AbortController | null = null;
-
-  const dispose = (): void => {
-    controller?.abort();
-    controller = null;
-  };
-
-  const begin = (): AbortSignal => {
-    dispose();
-
-    controller = new AbortController();
-    return controller.signal;
-  };
-
-  return {
-    begin,
-    dispose,
-  };
-})();
+const markEventScope = createEventScope();
 
 export const updateMark = (): void => {
   const article = document.getElementById('article');

--- a/js/mark.ts
+++ b/js/mark.ts
@@ -52,12 +52,6 @@ const markEventScope = (() => {
   };
 })();
 
-// Fail Fast
-const markButton = document.getElementById(TARGET_MARK_BUTTON);
-if (markButton === null) {
-  throw new Error('Missing Mark Button');
-}
-
 export const updateMark = (): void => {
   const article = document.getElementById('article');
 
@@ -91,20 +85,27 @@ const keyClear = (ev: KeyboardEvent): void => {
   }
 };
 
-const setIconColor = (color: string): void => {
-  const icon = markButton.querySelector(QUERY_MARKER) as HTMLDivElement;
+const setIconColor = (button: HTMLButtonElement, color: string): void => {
+  const icon = button.querySelector(QUERY_MARKER) as HTMLDivElement;
   icon.style.backgroundColor = color;
 };
 
 export const unmarking = (): void => {
   CSS.highlights.clear();
-  setIconColor(ICONS_COLOR);
 
-  markButton.ariaPressed = 'false';
+  const button = document.getElementById(TARGET_MARK_BUTTON);
+
+  if (!(button instanceof HTMLButtonElement)) {
+    return;
+  }
+
+  setIconColor(button, ICONS_COLOR);
+
+  button.ariaPressed = 'false';
 
   const signal = markEventScope.begin();
 
-  markButton.addEventListener('click', updateMark, {
+  button.addEventListener('click', updateMark, {
     passive: true,
     signal,
   });
@@ -119,17 +120,29 @@ const hideButton = (): void => {
   markEventScope.dispose();
   CSS.highlights.clear();
 
-  markButton.classList.add('hidden');
+  const button = document.getElementById(TARGET_MARK_BUTTON);
+
+  if (!(button instanceof HTMLButtonElement)) {
+    return;
+  }
+
+  button.classList.add('hidden');
 };
 
 const visibleButton = (): void => {
+  const button = document.getElementById(TARGET_MARK_BUTTON);
+
+  if (!(button instanceof HTMLButtonElement)) {
+    return;
+  }
+
   const signal = markEventScope.begin();
-  setIconColor(ICONS_COLOR_ACTIVE);
+  setIconColor(button, ICONS_COLOR_ACTIVE);
 
-  markButton.ariaPressed = 'true';
-  markButton.classList.remove('hidden');
+  button.ariaPressed = 'true';
+  button.classList.remove('hidden');
 
-  markButton.addEventListener('click', unmarking, {
+  button.addEventListener('click', unmarking, {
     passive: true,
     signal,
   });

--- a/js/navigation-store.ts
+++ b/js/navigation-store.ts
@@ -2,7 +2,7 @@ export default (() => {
   let url = new URL(location.href);
 
   return {
-    get url() {
+    get current() {
       return url;
     },
 

--- a/js/navigation.ts
+++ b/js/navigation.ts
@@ -1,6 +1,6 @@
 import { CONTENT_READY } from './constants.ts';
 import { type NavigationContext, prepareNavigation } from './context.ts';
-import navigationState from './navigationState.ts';
+import navigationState from './navigation-store.ts';
 import { bootThemeColor } from './theme-selector.ts';
 
 import { setHTML } from './utils/html-sanitizer.ts';

--- a/js/rolldown.config.mts
+++ b/js/rolldown.config.mts
@@ -7,6 +7,7 @@ const ENTRIES = [
 
   './extensions/codeblock.ts',
   './extensions/footnote.ts',
+  './extensions/footnote-legacy.ts',
   './extensions/media.ts',
   './extensions/slider.ts',
 ];

--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -23,13 +23,10 @@ const RESULT_HEADER_LEN_POSITION = 0;
 const RESULT_HTML_LEN_POSITION = LENGTH_FIELD_SIZE * 1;
 const RESULT_DATA_START = LENGTH_FIELD_SIZE * 2;
 
-// Fail Fast
-const elmPop = document.getElementById('search-pop');
-if (elmPop === null) {
-  throw new Error('Missing search popover');
-}
+const POP_ID = 'search-pop';
 
 let elmSearch: HTMLElement;
+let elmPop: HTMLElement;
 let elmSearchBar: HTMLInputElement;
 let elmHeader: HTMLElement;
 let elmResults: HTMLElement;
@@ -40,7 +37,8 @@ let focusedLi: Element | null;
 
 let searchAbort: AbortController;
 
-export const isSearchPopoverOpen = (): boolean => elmPop.matches(':popover-open');
+// NOTE: I'd rather not, but I have to use `getElementById` every time.
+export const isSearchPopoverOpen = (): boolean => document.getElementById(POP_ID)?.matches(':popover-open') ?? false;
 
 const showResults = (): void => {
   const bytes = finder.search(elmSearchBar.value);
@@ -197,12 +195,13 @@ const bootSearch = async (): Promise<void> => {
   document.removeEventListener('keyup', bootSearchFromKey);
 
   const elements = {
+    pop: document.getElementById(POP_ID),
     searchBar: document.getElementById('searchbar'),
     header: document.getElementById('results-header'),
     results: document.getElementById('searchresults'),
   };
 
-  if (elements.searchBar === null || elements.header === null || elements.results === null) {
+  if (elements.pop === null || elements.searchBar === null || elements.header === null || elements.results === null) {
     throw new Error('Required DOM elements not found');
   }
 
@@ -210,6 +209,7 @@ const bootSearch = async (): Promise<void> => {
     throw new Error('searchbar element is not an input element');
   }
 
+  elmPop = elements.pop;
   elmSearchBar = elements.searchBar;
   elmHeader = elements.header;
   elmResults = elements.results;
@@ -253,11 +253,6 @@ const bootSearchFromKey = (ev: KeyboardEvent): void => {
 };
 
 export const startupSearch = (): void => {
-  if (!elmPop) {
-    toast.error('Search is currently unavailable.');
-    return;
-  }
-
   const button = document.getElementById(TARGET_SEARCH_BUTTON);
 
   if (!(button instanceof HTMLButtonElement)) {

--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -10,7 +10,7 @@ import toast from './utils/toast.ts';
 // deno-lint-ignore no-sloppy-imports
 import initWasm, { Finder } from './wasm_book.js';
 
-export const TARGET_SEARCH = 'search';
+export const TARGET_SEARCH_BUTTON = 'search-btn';
 
 const FILE_STYLE_SEARCH = 'css/search.css';
 const FILE_INDEX = 'searchindex.json';
@@ -24,12 +24,12 @@ const RESULT_HTML_LEN_POSITION = LENGTH_FIELD_SIZE * 1;
 const RESULT_DATA_START = LENGTH_FIELD_SIZE * 2;
 
 // Fail Fast
-const elmPop = document.querySelector<HTMLElement>('#search-pop');
+const elmPop = document.getElementById('search-pop');
 if (elmPop === null) {
   throw new Error('Missing search popover');
 }
 
-let elmSearch: HTMLElement[];
+let elmSearch: HTMLElement;
 let elmSearchBar: HTMLInputElement;
 let elmHeader: HTMLElement;
 let elmResults: HTMLElement;
@@ -67,10 +67,8 @@ const checkURL = (url: URL): boolean =>
 
 const hiddenSearch = (): void => {
   elmPop.hidePopover();
+  elmSearch.ariaExpanded = 'false';
 
-  for (const x of elmSearch) {
-    x.ariaExpanded = 'false';
-  }
   searchAbort.abort();
 };
 
@@ -148,9 +146,7 @@ const showSearch = (): void => {
     return;
   }
 
-  for (const x of elmSearch) {
-    x.ariaExpanded = 'true';
-  }
+  elmSearch.ariaExpanded = 'true';
 
   elmPop.showPopover();
   elmSearchBar.select();
@@ -218,10 +214,8 @@ const bootSearch = async (): Promise<void> => {
   elmHeader = elements.header;
   elmResults = elements.results;
 
-  for (const x of elmSearch) {
-    x.removeEventListener('click', bootSearch);
-    x.addEventListener('click', showSearch, { passive: true });
-  }
+  elmSearch.removeEventListener('click', bootSearch);
+  elmSearch.addEventListener('click', showSearch, { passive: true });
 
   document.addEventListener('keyup', startSearchfromKey, {
     passive: true,
@@ -241,12 +235,9 @@ const bootSearch = async (): Promise<void> => {
     await cssPromise;
     showSearch();
   } catch (e: unknown) {
+    elmSearch.style.display = 'none';
+
     console.error(`Error during initialization: ${e}`);
-
-    for (const x of elmSearch) {
-      x.style.display = 'none';
-    }
-
     toast.error('Search is currently unavailable.');
   }
 };
@@ -267,11 +258,15 @@ export const startupSearch = (): void => {
     return;
   }
 
-  elmSearch = Array.from(document.querySelectorAll(`[data-target="${TARGET_SEARCH}"]`));
+  const button = document.getElementById(TARGET_SEARCH_BUTTON);
 
-  for (const x of elmSearch) {
-    x.addEventListener('click', bootSearch, { once: true, passive: true });
+  if (!(button instanceof HTMLButtonElement)) {
+    toast.error('Search is currently unavailable.');
+    return;
   }
+  elmSearch = button;
+
+  elmSearch.addEventListener('click', bootSearch, { once: true, passive: true });
 
   document.addEventListener('keyup', bootSearchFromKey, {
     passive: true,

--- a/js/serviceworker.ts
+++ b/js/serviceworker.ts
@@ -1,6 +1,6 @@
 declare const self: ServiceWorkerGlobalScope;
 
-const CACHE_VERSION = 'v11.7.1';
+const CACHE_VERSION = 'v11.8.0';
 
 const CACHE_URL = '/commentary/';
 const FALLBACK_IMAGE = 'favicon.png';

--- a/js/sidebar.ts
+++ b/js/sidebar.ts
@@ -2,13 +2,17 @@ import { BREAKPOINT_UI_WIDE, CONTENT_READY } from './constants.ts';
 import pagelist from './pagelist.ts';
 import { isSearchPopoverOpen } from './searcher.ts';
 
+import toast from './utils/toast.ts';
+
 const SHOW_SIDEBAR_WIDTH = 1200;
 
 const ID_PAGE = 'page';
 const ID_SIDEBAR = 'sidebar';
 const ID_SCROLLBOX = 'sidebar-scrollbox';
 
-const TARGET_TOGGLE = 'sidebar';
+const TARGET_SIDEBAR_BUTTON = 'sidebar-btn';
+
+let sidebarButton: HTMLButtonElement;
 
 let doneFirstScroll = false;
 
@@ -27,9 +31,7 @@ const hideSidebar = (): void => {
   sidebar.style.display = 'none';
   sidebar.ariaHidden = 'true';
 
-  for (const x of document.querySelectorAll(`[data-target="${TARGET_TOGGLE}"]`)) {
-    x.ariaExpanded = 'false';
-  }
+  sidebarButton.ariaExpanded = 'false';
 
   abortController?.abort();
 };
@@ -76,9 +78,7 @@ const showSidebar = async (): Promise<void> => {
   sidebar.style.display = 'block';
   sidebar.ariaHidden = null;
 
-  for (const x of document.querySelectorAll(`[data-target="${TARGET_TOGGLE}"]`)) {
-    x.ariaExpanded = 'true';
-  }
+  sidebarButton.ariaExpanded = 'true';
 
   const controller = new AbortController();
   abortController = controller;
@@ -132,6 +132,14 @@ const clearActive = (): void => {
 };
 
 export const bootSidebar = (): void => {
+  const button = document.getElementById(TARGET_SIDEBAR_BUTTON);
+
+  if (!(button instanceof HTMLButtonElement)) {
+    toast.error('Sidebar is currently unavailable.');
+    return;
+  }
+  sidebarButton = button;
+
   globalThis.innerWidth < BREAKPOINT_UI_WIDE ? hideSidebar() : showSidebar();
 
   document.addEventListener('keyup', ev => toggleHandler(ev.key), {
@@ -148,11 +156,9 @@ export const bootSidebar = (): void => {
     { passive: true },
   );
 
-  for (const x of document.querySelectorAll(`[data-target="${TARGET_TOGGLE}"]`)) {
-    x.addEventListener('click', toggleSidebar, {
-      passive: true,
-    });
-  }
+  sidebarButton.addEventListener('click', toggleSidebar, {
+    passive: true,
+  });
 
   document.addEventListener(CONTENT_READY, clearActive, {
     passive: true,

--- a/js/test/searcher.test.ts
+++ b/js/test/searcher.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
-import { startupSearch, TARGET_SEARCH } from '../searcher.ts';
+import { startupSearch, TARGET_SEARCH_BUTTON } from '../searcher.ts';
 
 // Mock modules before imports
 vi.mock('../utils/css-loader.ts', () => ({
@@ -93,9 +93,9 @@ describe('Searcher Module', () => {
 
   describe('startupSearch', () => {
     it('should initialize search with correct event listeners on search button', () => {
-      const searchButton = document.querySelector<HTMLButtonElement>(`[data-target="${TARGET_SEARCH}"]`)!;
+      const searchButton = document.getElementById(TARGET_SEARCH_BUTTON);
       const mockAddEventListener = vi.fn();
-      searchButton.addEventListener = mockAddEventListener;
+      searchButton!.addEventListener = mockAddEventListener;
 
       startupSearch();
 
@@ -113,7 +113,7 @@ describe('Searcher Module', () => {
     });
 
     it('should handle missing search toggle element gracefully', () => {
-      const searchButton = document.querySelector(`[data-target="${TARGET_SEARCH}"]`);
+      const searchButton = document.getElementById(TARGET_SEARCH_BUTTON);
       searchButton?.remove();
 
       expect(() => startupSearch()).not.toThrow();
@@ -140,8 +140,8 @@ describe('Searcher Module', () => {
 
       startupSearch();
 
-      const searchButton = document.querySelector<HTMLButtonElement>(`[data-target="${TARGET_SEARCH}"]`)!;
-      searchButton.click();
+      const searchButton = document.getElementById(TARGET_SEARCH_BUTTON);
+      searchButton?.click();
 
       await vi.runAllTimersAsync();
 
@@ -160,8 +160,8 @@ describe('Searcher Module', () => {
 
       startupSearch();
 
-      const searchButton = document.querySelector<HTMLButtonElement>(`[data-target="${TARGET_SEARCH}"]`)!;
-      searchButton.click();
+      const searchButton = document.getElementById(TARGET_SEARCH_BUTTON);
+      searchButton?.click();
 
       await vi.runAllTimersAsync();
 
@@ -212,7 +212,7 @@ describe('Searcher Module', () => {
 
       startupSearch();
 
-      const toggle = document.querySelector(`[data-target="${TARGET_SEARCH}"]`)!;
+      const toggle = document.getElementById(TARGET_SEARCH_BUTTON);
       const searchPop = document.getElementById('search-pop') as HTMLElement;
 
       // Mock the popover to report as visible after being shown

--- a/js/test/searcher.test.ts
+++ b/js/test/searcher.test.ts
@@ -65,7 +65,7 @@ globalThis.DecompressionStream = MockDecompressionStream;
 describe('Searcher Module', () => {
   beforeEach(() => {
     document.body.innerHTML = `
-      <button data-target=${TARGET_SEARCH} class="icon-button" title="Toggle Search Box (Shortkey: / )" aria-label="Toggle Search Box" aria-expanded="false" aria-keyshortcuts="S" aria-controls="searchbar">
+      <button type="button" data-target="search" id="search-btn" class="icon-button" title="Toggle Search Box (Shortkey: / )" aria-label="Toggle Search Box" aria-keyshortcuts="/" aria-controls="search-pop">
         <div class="icon-search fa-icon"></div>
       </button>
 

--- a/js/theme-selector.ts
+++ b/js/theme-selector.ts
@@ -33,7 +33,7 @@ const KEY_SAVE_STORAGE = 'mdbook-theme';
 const KEY_DARK = ':dark';
 const KEY_LIGHT = ':light';
 
-const TARGET_THEME_SELECTOR = 'theme-selector';
+const TARGET_THEME_BUTTON = 'theme-btn';
 
 const ID_PAGE = 'page';
 const ID_THEME_LIST = 'theme-list';
@@ -241,16 +241,21 @@ export const bootThemeColor = (): Promise<void> => {
       }
     });
 
+  const button = document.getElementById(TARGET_THEME_BUTTON);
+
+  if (button === null) {
+    toast.error('Theme selection is currently unavailable.');
+    return loadStylePromise;
+  }
+
   prefersColor.addEventListener('change', changeEvent, {
     passive: true,
   });
 
-  for (const x of document.querySelectorAll(`[data-target="${TARGET_THEME_SELECTOR}"]`)) {
-    x.addEventListener('click', initThemeSelector, {
-      passive: true,
-      signal: abortInitTheme.signal,
-    });
-  }
+  button.addEventListener('click', initThemeSelector, {
+    passive: true,
+    signal: abortInitTheme.signal,
+  });
 
   document.addEventListener(
     'keyup',

--- a/js/utils/abort-scope.ts
+++ b/js/utils/abort-scope.ts
@@ -1,4 +1,8 @@
-export const createEventScope = () => {
+/**
+ * Manages a single active AbortController.
+ * Calling begin() disposes the previous scope.
+ */
+export const createAbortScope = () => {
   let controller: AbortController | null = null;
 
   const dispose = (): void => {

--- a/js/utils/event-scope.ts
+++ b/js/utils/event-scope.ts
@@ -1,0 +1,21 @@
+export const createEventScope = () => {
+  let controller: AbortController | null = null;
+
+  const dispose = (): void => {
+    controller?.abort();
+    controller = null;
+  };
+
+  const begin = (): AbortSignal => {
+    dispose();
+
+    controller = new AbortController();
+
+    return controller.signal;
+  };
+
+  return {
+    begin,
+    dispose,
+  };
+};

--- a/js/vitest.config.ts
+++ b/js/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'happy-dom',
-    include: ['test/link.test.ts'],// FIXME: Temporarily ignoring 'searcher.test.ts'...
+    include: ['test/*.test.ts'],
   },
 });

--- a/rs/mdbook-footnote/src/lib.rs
+++ b/rs/mdbook-footnote/src/lib.rs
@@ -28,7 +28,7 @@ pub fn replacing(mut book: Book) -> Result<Book, Error> {
                     s.push_str(idx);
                     s.push_str("\" data-href=\"#ft-");
                     s.push_str(idx);
-                    s.push_str("\" aria-expand=\"false\">");
+                    s.push_str("\" aria-expanded=\"false\">");
                     s.push_str(idx);
                     s.push_str("</button></sup>");
 

--- a/rs/mdbook-footnote/src/lib.rs
+++ b/rs/mdbook-footnote/src/lib.rs
@@ -28,7 +28,7 @@ pub fn replacing(mut book: Book) -> Result<Book, Error> {
                     s.push_str(idx);
                     s.push_str("\" data-href=\"#ft-");
                     s.push_str(idx);
-                    s.push_str("\">");
+                    s.push_str("\" aria-expand=\"false\">");
                     s.push_str(idx);
                     s.push_str("</button></sup>");
 

--- a/rs/mdbook-footnote/test/ok.md
+++ b/rs/mdbook-footnote/test/ok.md
@@ -1,7 +1,7 @@
 # 🎠 Watching the Wheels
 
 ```admonish success title=""
-I'm just sitting here watching the wheels<sup class="ft-reference"><button type="button" id="to-ft-1" data-href="#ft-1" aria-expand="false">1</button></sup>go 'round and 'round
+I'm just sitting here watching the wheels<sup class="ft-reference"><button type="button" id="to-ft-1" data-href="`#ft-1`" aria-expanded="false">1</button></sup>go 'round and 'round
 
 I really love to watch them roll
 

--- a/rs/mdbook-footnote/test/ok.md
+++ b/rs/mdbook-footnote/test/ok.md
@@ -1,7 +1,7 @@
 # 🎠 Watching the Wheels
 
 ```admonish success title=""
-I'm just sitting here watching the wheels<sup class="ft-reference"><button type="button" id="to-ft-1" data-href="`#ft-1`" aria-expanded="false">1</button></sup>go 'round and 'round
+I'm just sitting here watching the wheels<sup class="ft-reference"><button type="button" id="to-ft-1" data-href="#ft-1" aria-expanded="false">1</button></sup>go 'round and 'round
 
 I really love to watch them roll
 

--- a/rs/mdbook-footnote/test/ok.md
+++ b/rs/mdbook-footnote/test/ok.md
@@ -1,7 +1,7 @@
 # 🎠 Watching the Wheels
 
 ```admonish success title=""
-I'm just sitting here watching the wheels<sup class="ft-reference"><button type="button" id="to-ft-1" data-href="#ft-1">1</button></sup>go 'round and 'round
+I'm just sitting here watching the wheels<sup class="ft-reference"><button type="button" id="to-ft-1" data-href="#ft-1" aria-expand="false">1</button></sup>go 'round and 'round
 
 I really love to watch them roll
 

--- a/scss/_footnote.scss
+++ b/scss/_footnote.scss
@@ -29,12 +29,9 @@
 }
 
 .ft-pop {
-  position: absolute;
-  left: 0;
-  right: 0;
-  width: 84dvw;
-  margin-left: auto;
-  margin-right: auto;
+  position-area: bottom;
+  position-try-fallbacks: top;
+  inset-inline: 8rem;
 
   color: var(--fg);
   background-color: var(--popup-bg);
@@ -45,17 +42,7 @@
   border-radius: .8rem;
   font-size: .64rem;
   text-align: left;
-  overflow-y: scroll;
-
-  transform: scale(0.95);
-  opacity: 0;
-  transition: opacity 150ms ease, transform 150ms ease;
-
-  &.show {
-    opacity: 1;
-    transform: scale(1);
-    z-index: 100;
-  }
+  overflow-y: auto;
 
   a {
     text-decoration: none;

--- a/scss/_presentation.scss
+++ b/scss/_presentation.scss
@@ -68,14 +68,6 @@ mark {
   text-decoration: underline var(--search-mark-bg);
 }
 
-:popover-open {
-  top: var.$menu-bar-height;
-
-  color: var(--fg);
-  background-color: var(--popup-bg);
-  border: 0.1rem solid var(--popup-border);
-}
-
 .table-wrapper {
   overflow-x: auto; // make wide tables scroll if they overflow
 

--- a/scss/build.ts
+++ b/scss/build.ts
@@ -11,7 +11,15 @@ const CLR_C = '\x1b[36m';
 
 const OUT_DIR = 'dist/';
 
-const FILES = ['general', 'search', 'style', 'theme-list'];
+// biome-ignore format: keep SCSS filelist readable
+const SCSS_FILE_LIST = [
+  "footnote",
+  "footnote-legacy",
+  "general",
+  "search",
+  "style",
+  "theme-list",
+];
 
 const THEME_DIR = 'catppuccin/';
 const THEME_FILES = ['au-lait', 'frappe', 'latte', 'macchiato', 'mocha'];
@@ -56,12 +64,12 @@ const build = async (input: string, output: string): Promise<void> => {
   await Promise.all([ensureDir(OUT_DIR), ensureDir(`${OUT_DIR}${THEME_DIR}`)]);
 
   const list = [
-    { dir: '', files: FILES },
+    { dir: '', files: SCSS_FILE_LIST },
     { dir: THEME_DIR, files: THEME_FILES },
   ];
 
   await Promise.all(list.flatMap(x => x.files.map(file => build(`${x.dir}${file}.scss`, `${x.dir}${file}.css`))));
 
   const time = Math.floor(performance.now() - start);
-  console.info(`${CLR_BG}✔ ${CLR_BC}sass${CLR_RESET} Finished in ${CLR_BG}${time} ms${CLR_RESET}\n`);
+  console.info(`${CLR_BG}√ ${CLR_BC}sass${CLR_RESET} Finished in ${CLR_BG}${time} ms${CLR_RESET}\n`);
 })();

--- a/scss/footnote-legacy.scss
+++ b/scss/footnote-legacy.scss
@@ -47,15 +47,7 @@
   text-align: left;
   overflow-y: scroll;
 
-  transform: scale(0.95);
-  opacity: 0;
-  transition: opacity 150ms ease, transform 150ms ease;
-
-  &.show {
-    opacity: 1;
-    transform: scale(1);
-    z-index: 100;
-  }
+  z-index: 100;
 
   a {
     text-decoration: none;

--- a/scss/footnote-legacy.scss
+++ b/scss/footnote-legacy.scss
@@ -29,9 +29,12 @@
 }
 
 .ft-pop {
-  position-area: bottom;
-  position-try-fallbacks: top;
-  inset-inline: 8rem;
+  position: absolute;
+  left: 0;
+  right: 0;
+  width: 84dvw;
+  margin-left: auto;
+  margin-right: auto;
 
   color: var(--fg);
   background-color: var(--popup-bg);
@@ -42,7 +45,17 @@
   border-radius: .8rem;
   font-size: .64rem;
   text-align: left;
-  overflow-y: auto;
+  overflow-y: scroll;
+
+  transform: scale(0.95);
+  opacity: 0;
+  transition: opacity 150ms ease, transform 150ms ease;
+
+  &.show {
+    opacity: 1;
+    transform: scale(1);
+    z-index: 100;
+  }
 
   a {
     text-decoration: none;

--- a/scss/footnote.scss
+++ b/scss/footnote.scss
@@ -1,0 +1,55 @@
+@use 'variables.scss' as var;
+
+.ft-definition {
+  font-size: 0.75em;
+  margin-top: 0.8em;
+  scroll-margin-top: var.$menu-bar-height;
+
+  a {
+    text-decoration: none;
+  }
+
+  p {
+    display: inline;
+  }
+}
+
+.ft-reference {
+  button {
+    text-decoration: none;
+    scroll-margin-top: var.$menu-bar-height;
+
+    background: none;
+    border: none;
+    color: var(--links);
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+  }
+}
+
+.ft-pop {
+  contain: content;
+  position-area: bottom;
+  position-try-fallbacks: top;
+  inset-inline: 1rem;
+
+  padding: 0.8rem;
+  border-radius: 0.8rem;
+  font-size: 0.64rem;
+
+  a {
+    text-decoration: none;
+
+    &:link,
+    &:visited {
+      color: var(--links);
+      margin-left: .2em;
+      margin-right: .2em;
+    }
+  }
+
+  p {
+    display: inline;
+  }
+}

--- a/scss/general.scss
+++ b/scss/general.scss
@@ -116,9 +116,6 @@ body {
     @include utils.filter-glass($radius: 1.6rem);
 
     #menu {
-      #left-buttons {
-        gap: 0.4rem;
-      }
 
       #book-title,
       #right-buttons {

--- a/scss/general.scss
+++ b/scss/general.scss
@@ -8,6 +8,13 @@
   navigation: auto;
 }
 
+[popover] {
+  color: var(--fg);
+  background-color: var(--popup-bg);
+
+  border: 0.1rem solid var(--popup-border);
+}
+
 html {
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;

--- a/scss/general.scss
+++ b/scss/general.scss
@@ -56,56 +56,73 @@ body {
   }
 }
 
-@media (max-width: var.$breakpoint-ui-wide) {
-  header {
-    display: none;
+@media (min-width: var.$breakpoint-ui-wide) {
+  #top-bar {
+    flex-basis: var.$menu-bar-height;
+    z-index: 40;
+
+    #menu {
+      position: fixed;
+      display: flex;
+
+      width: 100dvw;
+      height: var.$menu-bar-height;
+
+      align-items: center;
+      gap: 0.8rem;
+
+      background-color: var(--bg);
+
+      opacity: 0.92;
+      contain: paint;
+
+      #left-buttons {
+        margin-left: 1rem;
+        display: flex;
+        gap: 0.8rem;
+      }
+
+      #book-title {
+        flex: 1;
+        color: var(--icons);
+        font-family: var.$italic-font;
+        font-size: 0.7em;
+        font-style: italic;
+        text-align: right;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      #right-buttons {
+        margin-right: 2rem;
+
+        &>a {
+          text-decoration: none;
+          color: inherit;
+        }
+      }
+    }
   }
 }
 
-#top-bar {
-  flex-basis: var.$menu-bar-height;
+@media (max-width: var.$breakpoint-ui-wide) {
+  #top-bar {
+    position: fixed;
+    z-index: 40;
 
-  #menu {
-    height: var.$menu-bar-height;
-    display: flex;
-    align-items: center;
-    gap: 0.8rem;
+    top: calc(env(safe-area-inset-top) + 0.1rem);
+    padding: 0.4rem;
 
-    background-color: var(--bg);
+    @include utils.filter-glass($radius: 1.6rem);
 
-    z-index: 30;
-    opacity: 0.92;
-    contain: paint;
+    #menu {
+      #left-buttons {
+        gap: 0.4rem;
+      }
 
-    @media (min-width: var.$breakpoint-ui-wide) {
-      position: fixed;
-      width: 100dvw;
-    }
-
-    #left-buttons {
-      min-width: 0;
-      margin-left: 1rem;
-      display: flex;
-      gap: 0.8rem;
-    }
-
-    #book-title {
-      flex: 1;
-      color: var(--icons);
-      font-family: var.$italic-font;
-      font-size: 0.7em;
-      font-style: italic;
-      text-align: right;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    #right-buttons {
-      margin-right: 2rem;
-
-      &>a {
-        text-decoration: none;
-        color: inherit;
+      #book-title,
+      #right-buttons {
+        display: none;
       }
     }
   }
@@ -301,26 +318,6 @@ article {
     &>#next {
       margin-left: auto;
     }
-  }
-}
-
-.compact-container {
-  display: none;
-  contain: paint;
-
-  @media (max-width: var.$breakpoint-ui-wide) {
-    position: fixed;
-    display: flex;
-
-    justify-content: center;
-    align-items: center;
-    gap: 0.4rem;
-
-    top: calc(env(safe-area-inset-top) + 0.1rem);
-    padding: 0.4rem;
-    z-index: 40;
-
-    @include utils.filter-glass($radius: 1.6rem);
   }
 }
 

--- a/scss/search.scss
+++ b/scss/search.scss
@@ -2,9 +2,14 @@
 @use "utils" as utils;
 
 #search-pop {
+  inset-block-start: 4rem;
+  inset-block-end: auto;
+  inset-inline: 2rem;
+  margin-inline: auto;
+
   width: 84dvw;
   max-height: 88dvh;
-  margin: 0 auto;
+
   overflow-x: hidden;
   overflow-y: scroll;
 

--- a/scss/search.scss
+++ b/scss/search.scss
@@ -2,10 +2,7 @@
 @use "utils" as utils;
 
 #search-pop {
-  inset-block-start: 4rem;
-  inset-block-end: auto;
-  inset-inline: 2rem;
-  margin-inline: auto;
+  inset-block: 2.8rem auto;
 
   width: 84dvw;
   max-height: 88dvh;

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -4,7 +4,6 @@
 
 @use 'additional-admonish';
 
-@use 'footnote';
 @use 'slider';
 @use 'table-of-contents';
 @use 'toast';

--- a/scss/theme-list.scss
+++ b/scss/theme-list.scss
@@ -8,9 +8,7 @@ kbd,
   transition: color 0.5s, border-color 0.4s, background-color 0.3s;
 }
 
-// NOTE: If this class is used in two or more places, ensure that only one instance is displayed
-// (the others should be `display: none`).
-.theme-pop {
+#theme-btn {
   anchor-name: $pop-anchor;
 }
 

--- a/scss/theme-list.scss
+++ b/scss/theme-list.scss
@@ -1,3 +1,5 @@
+$pop-anchor: --theme-list;
+
 body,
 code,
 kbd,
@@ -6,12 +8,23 @@ kbd,
   transition: color 0.5s, border-color 0.4s, background-color 0.3s;
 }
 
-#theme-list {
-  margin: 0 2.4rem;
-  padding: 0.4rem;
-  font-size: 0.7rem;
+// NOTE: If this class is used in two or more places, ensure that only one instance is displayed
+// (the others should be `display: none`).
+.theme-pop {
+  anchor-name: $pop-anchor;
+}
 
+#theme-list {
+  position-anchor: $pop-anchor;
+  position-area: center y-end;
+
+  margin-block-start: 0.8rem;
+  margin-inline-start: 2rem;
+
+  padding: 0.4rem;
   border-radius: 0.4rem;
+
+  font-size: 0.8rem;
 
   &:popover-open {
     display: flex;

--- a/scss/theme-list.scss
+++ b/scss/theme-list.scss
@@ -16,7 +16,8 @@ kbd,
   position-anchor: $pop-anchor;
   position-area: center y-end;
 
-  margin-block-start: 0.8rem;
+  inset-block: .8rem auto;
+
   margin-inline-start: 2rem;
 
   padding: 0.4rem;

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -96,10 +96,9 @@
           <div class="icon-menu fa-icon"></div>
         </button>
       </aside>
-
     </div>
 
-    <div id="search-pop" tabindex="-1" popover role="dialog" aria-label="Search">
+    <div popover id="search-pop" role="dialog" aria-label="Search">
       <input type="search" id="searchbar" name="searchbar" placeholder="Search this book ..." aria-controls="searchresults" aria-describedby="results-header">
 
       <div id="results-header" aria-live="polite"></div>

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -39,7 +39,7 @@
           <button type="button" data-target="sidebar" class="icon-button" title="Toggle Page List (Shortkey: T )" aria-label="Toggle Page List" aria-keyshortcuts="T" aria-controls="sidebar">
             <div class="icon-sidebar fa-icon"></div>
           </button>
-          <button type="button" popovertarget="theme-list" data-target="theme-selector" class="icon-button" title="Theme selection (Shortkey: C )" aria-label="Theme selection" aria-haspopup="true" aria-controls="theme-list">
+          <button type="button" popovertarget="theme-list" data-target="theme-selector" class="theme-pop icon-button" title="Theme selection (Shortkey: C )" aria-label="Theme selection" aria-haspopup="true" aria-controls="theme-list">
             <div class="icon-theme fa-icon"></div>
           </button>
           <button type="button" data-target="search" class="icon-button" title="Toggle Search Box (Shortkey: / )" aria-label="Toggle Search Box" aria-keyshortcuts="/" aria-controls="search-pop">
@@ -91,7 +91,7 @@
         <button type="button" data-target="sidebar" class="icon-button" title="Toggle Page List (Shortkey: T )" aria-label="Toggle Page List" aria-keyshortcuts="T" aria-controls="sidebar">
           <div class="icon-sidebar fa-icon"></div>
         </button>
-        <button type="button" popovertarget="theme-list" data-target="theme-selector" class="icon-button" title="Theme selection (Shortkey: C )" aria-label="Theme selection" aria-haspopup="true" aria-controls="theme-list">
+        <button type="button" popovertarget="theme-list" data-target="theme-selector" class="theme-pop icon-button" title="Theme selection (Shortkey: C )" aria-label="Theme selection" aria-haspopup="true" aria-controls="theme-list">
           <div class="icon-theme fa-icon"></div>
         </button>
         <button type="button" data-target="search" class="icon-button" title="Toggle Search Box (Shortkey: / )" aria-label="Toggle Search Box" aria-keyshortcuts="/" aria-controls="search-pop">

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -36,16 +36,16 @@
     <header id="top-bar">
       <div id="menu" role="toolbar" aria-label="Action menu">
         <div id="left-buttons">
-          <button type="button" data-target="sidebar" class="icon-button" title="Toggle Page List (Shortkey: T )" aria-label="Toggle Page List" aria-keyshortcuts="T" aria-controls="sidebar">
+          <button type="button" data-target="sidebar" id="sidebar-btn" class="icon-button" title="Toggle Page List (Shortkey: T )" aria-label="Toggle Page List" aria-keyshortcuts="T" aria-controls="sidebar">
             <div class="icon-sidebar fa-icon"></div>
           </button>
-          <button type="button" popovertarget="theme-list" data-target="theme-selector" class="theme-pop icon-button" title="Theme selection (Shortkey: C )" aria-label="Theme selection" aria-haspopup="true" aria-controls="theme-list">
+          <button type="button" popovertarget="theme-list" data-target="theme-selector" id="theme-btn" class="icon-button" title="Theme selection (Shortkey: C )" aria-label="Theme selection" aria-haspopup="true" aria-controls="theme-list">
             <div class="icon-theme fa-icon"></div>
           </button>
-          <button type="button" data-target="search" class="icon-button" title="Toggle Search Box (Shortkey: / )" aria-label="Toggle Search Box" aria-keyshortcuts="/" aria-controls="search-pop">
+          <button type="button" data-target="search" id="search-btn" class="icon-button" title="Toggle Search Box (Shortkey: / )" aria-label="Toggle Search Box" aria-keyshortcuts="/" aria-controls="search-pop">
             <div class="icon-search fa-icon"></div>
           </button>
-          <button type="button" data-target="marking" class="icon-button hidden" title="Toggle Marker (Shortkey: M )" aria-label="Toggle Marker" aria-keyshortcuts="M">
+          <button type="button" data-target="marking" id="mark-btn" class="icon-button hidden" title="Toggle Marker (Shortkey: M )" aria-label="Toggle Marker" aria-keyshortcuts="M">
             <div class="icon-marker fa-icon"></div>
           </button>
         </div>
@@ -86,21 +86,6 @@
           </nav>
         </article>
       </main>
-
-      <aside class="compact-container" aria-label="Action menu">
-        <button type="button" data-target="sidebar" class="icon-button" title="Toggle Page List (Shortkey: T )" aria-label="Toggle Page List" aria-keyshortcuts="T" aria-controls="sidebar">
-          <div class="icon-sidebar fa-icon"></div>
-        </button>
-        <button type="button" popovertarget="theme-list" data-target="theme-selector" class="theme-pop icon-button" title="Theme selection (Shortkey: C )" aria-label="Theme selection" aria-haspopup="true" aria-controls="theme-list">
-          <div class="icon-theme fa-icon"></div>
-        </button>
-        <button type="button" data-target="search" class="icon-button" title="Toggle Search Box (Shortkey: / )" aria-label="Toggle Search Box" aria-keyshortcuts="/" aria-controls="search-pop">
-          <div class="icon-search fa-icon"></div>
-        </button>
-        <button type="button" data-target="marking" class="icon-button hidden" title="Toggle Marker (Shortkey: M )" aria-label="Toggle Marker" aria-keyshortcuts="M">
-          <div class="icon-marker fa-icon"></div>
-        </button>
-      </aside>
 
       <aside class="toc-container" aria-label="Table of contents">
         <div id="table-of-contents">


### PR DESCRIPTION
While the focus of this PR is undoubtedly on making more active use of the `Popover API`,
a site-wide refactoring was also carried out at the same time.

To put it simply, we're updating outdated code!

I'm sure Rabbit will do a great job summarizing the update details!

p.s.
As for `footnote`s, browsers that use WebKit will continue to use legacy code.
(Using popovers in this environment causes the display to flicker when scrolling, which doesn't look very good...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Footnotes now use native anchored popovers for a more consistent reading experience.
  * Added a legacy footnote fallback for environments that don’t support full popover behavior.

* **Bug Fixes**
  * Improved accessibility state handling for footnote and toggle controls.
  * Refined responsive layout and popover positioning across screen sizes.

* **UI/Accessibility**
  * Sidebar, theme, search, and marking controls are now driven from single toolbar buttons (with improved focus/ARIA behavior).
  
* **Chores**
  * Updated offline caching version to pick up the latest assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->