### PR TITLE
refactor(video): use `Video.js` from CDN 🎮

### DIFF
--- a/js/deno.jsonc
+++ b/js/deno.jsonc
@@ -1,6 +1,5 @@
 {
   "imports": {
-    "@videojs/html": "npm:@videojs/html@10.0.0-beta.26",
     "rolldown": "npm:rolldown@1.2.3",
 
     "vitest": "npm:vitest@4.1.10",

--- a/js/deno.lock
+++ b/js/deno.lock
@@ -1,7 +1,6 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@videojs/html@10.0.0-beta.26": "10.0.0-beta.26_@svta+cml-cta@1.0.6__@svta+cml-structured-field-values@1.1.3___@svta+cml-utils@1.5.0__@svta+cml-utils@1.5.0_@svta+cml-structured-field-values@1.1.3__@svta+cml-utils@1.5.0_@svta+cml-utils@1.5.0",
     "npm:@vitest/coverage-v8@4.1.10": "4.1.10_vitest@4.1.10_happy-dom@20.11.1_vite@8.2.0",
     "npm:happy-dom@20.11.1": "20.11.1",
     "npm:rolldown@1.2.3": "1.2.3",
@@ -42,21 +41,6 @@
       "dependencies": [
         "@jridgewell/resolve-uri",
         "@jridgewell/sourcemap-codec"
-      ]
-    },
-    "@lit-labs/ssr-dom-shim@1.6.0": {
-      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ=="
-    },
-    "@lit/context@1.1.6": {
-      "integrity": "sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==",
-      "dependencies": [
-        "@lit/reactive-element"
-      ]
-    },
-    "@lit/reactive-element@2.1.2": {
-      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
-      "dependencies": [
-        "@lit-labs/ssr-dom-shim"
       ]
     },
     "@oxc-project/types@0.143.0": {
@@ -138,66 +122,6 @@
     "@standard-schema/spec@1.1.0": {
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
     },
-    "@svta/cml-608@1.0.2": {
-      "integrity": "sha512-ZEJ68330gcLKfvVv6Qifr1HR7+GldDUxzkjqSbqRK7jHtHSLSV1JAyDwlYe8+C7ABuY1bp8MpgJ4/Gg+jl+pLQ=="
-    },
-    "@svta/cml-cmcd@2.3.2_@svta+cml-structured-field-values@1.1.3__@svta+cml-utils@1.5.0_@svta+cml-utils@1.5.0": {
-      "integrity": "sha512-SKBBjLmci0WK8HMjuv+36tVIMktonoOoxsXblOFZmB+ePPV2zjRMTD+2ZmE/1VEPJkKHENyhSjSHgJyeOlvZ1A==",
-      "dependencies": [
-        "@svta/cml-structured-field-values",
-        "@svta/cml-utils"
-      ]
-    },
-    "@svta/cml-cmsd@1.0.6_@svta+cml-cta@1.0.6__@svta+cml-structured-field-values@1.1.3___@svta+cml-utils@1.5.0__@svta+cml-utils@1.5.0_@svta+cml-structured-field-values@1.1.3__@svta+cml-utils@1.5.0_@svta+cml-utils@1.5.0": {
-      "integrity": "sha512-LUORV6bb0TbU4rSC2HoPqUCix1igLrXkRQXWiIyJo2OMzb14kAK/1jsW0mzY6up6w1GrjKQcjc6OwqJdo/zd/g==",
-      "dependencies": [
-        "@svta/cml-cta",
-        "@svta/cml-structured-field-values",
-        "@svta/cml-utils"
-      ]
-    },
-    "@svta/cml-cta@1.0.6_@svta+cml-structured-field-values@1.1.3__@svta+cml-utils@1.5.0_@svta+cml-utils@1.5.0": {
-      "integrity": "sha512-l13/4myTX1EbRd38nY8J1umVY5UdR/nZO6CeKqVLXnMMIayg7/fu0TueZckjTA9Loal55MGK1xbHnXVjz7OUUw==",
-      "dependencies": [
-        "@svta/cml-structured-field-values",
-        "@svta/cml-utils"
-      ]
-    },
-    "@svta/cml-dash@1.0.6_@svta+cml-utils@1.5.0": {
-      "integrity": "sha512-4XtHYlPrzL/dRe/8XmRQoLnTo9S86tISgrl67eUqKl5MtNTpZBYTncuPrspslPZPZROBBWNrBuepYfYUtU9CKA==",
-      "dependencies": [
-        "@svta/cml-utils"
-      ]
-    },
-    "@svta/cml-id3@1.0.6_@svta+cml-utils@1.5.0": {
-      "integrity": "sha512-63j8gkAnPOmOBWlp0hIZPvsIioZttdbg6/TgwITqMYbSLYVJ+6QGa/UtIP0I84NsfstANw6QdCn7i8SS08kn1A==",
-      "dependencies": [
-        "@svta/cml-utils"
-      ]
-    },
-    "@svta/cml-request@1.0.12_@svta+cml-cmcd@2.3.2__@svta+cml-structured-field-values@1.1.3___@svta+cml-utils@1.5.0__@svta+cml-utils@1.5.0_@svta+cml-utils@1.5.0_@svta+cml-xml@1.1.4__@svta+cml-utils@1.5.0_@svta+cml-structured-field-values@1.1.3__@svta+cml-utils@1.5.0": {
-      "integrity": "sha512-4sJvnnoNpq58j2mCGP8k+MF6wVy/qa4gbt6kfT1dPIKmn3mPxw+JVfilhcWsUi+peK2yCZxOJJYyHj1cAcQE1w==",
-      "dependencies": [
-        "@svta/cml-cmcd",
-        "@svta/cml-utils",
-        "@svta/cml-xml"
-      ]
-    },
-    "@svta/cml-structured-field-values@1.1.3_@svta+cml-utils@1.5.0": {
-      "integrity": "sha512-XqLzQOTznz6kh/nsSh8dy1kV7GQjL4csG+2U5EvLGhAqNuNUczbVg5EAsDobKDVg8xhdthdXx2UuwM+ZHQCxSg==",
-      "dependencies": [
-        "@svta/cml-utils"
-      ]
-    },
-    "@svta/cml-utils@1.5.0": {
-      "integrity": "sha512-JMqclD7Akd+GSJiuaYNUHOP2wNtf/nauKeszlYeivSHfi0Lp3pmSW5PXDvJ2dO4aPmmSOQbF0ztTsW9Vcs2Whw=="
-    },
-    "@svta/cml-xml@1.1.4_@svta+cml-utils@1.5.0": {
-      "integrity": "sha512-jbixqjiJIc16SGxylHwiOzO+DuhkGfuP+fJ9AHeVJKdFDKnabgfCDpnp6dvZpZnjMj4nHvzVtuUV7RISPIwYXw==",
-      "dependencies": [
-        "@svta/cml-utils"
-      ]
-    },
     "@types/chai@5.2.3": {
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dependencies": [
@@ -224,69 +148,6 @@
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dependencies": [
         "@types/node"
-      ]
-    },
-    "@videojs/core@10.0.0-beta.26_@svta+cml-cta@1.0.6__@svta+cml-structured-field-values@1.1.3___@svta+cml-utils@1.5.0__@svta+cml-utils@1.5.0_@svta+cml-structured-field-values@1.1.3__@svta+cml-utils@1.5.0_@svta+cml-utils@1.5.0_@videojs+element@10.0.0-beta.26": {
-      "integrity": "sha512-qS6/CGERcktdy0AS7y/mXhd2TIHhjJuN2TH+xGaBq5umtn6W3wYjziw0gy3mS2MUfJMZvUPcNjxOgxZXD44KFA==",
-      "dependencies": [
-        "@videojs/media",
-        "@videojs/store",
-        "@videojs/utils"
-      ]
-    },
-    "@videojs/element@10.0.0-beta.26": {
-      "integrity": "sha512-iq1RbQEw0JaC7UczildK5IVpP55/ZCaN2MvrDBuKF3kZfgNn+rCCzmGcj4uzipGn7zqA3kPHRWzX1zrEWP1CMg==",
-      "dependencies": [
-        "@lit/context"
-      ]
-    },
-    "@videojs/html@10.0.0-beta.26_@svta+cml-cta@1.0.6__@svta+cml-structured-field-values@1.1.3___@svta+cml-utils@1.5.0__@svta+cml-utils@1.5.0_@svta+cml-structured-field-values@1.1.3__@svta+cml-utils@1.5.0_@svta+cml-utils@1.5.0": {
-      "integrity": "sha512-BM7U4UwmB2Xqnpo9Bwwgq7HJnFK6EmJlN+cxOfsm/LcDo3TMXxXcuZqXXzzMJ3H5tAcnzysJZKX7ppgIbxBa/w==",
-      "dependencies": [
-        "@videojs/core",
-        "@videojs/element",
-        "@videojs/media",
-        "@videojs/spf",
-        "@videojs/store",
-        "@videojs/utils"
-      ]
-    },
-    "@videojs/media@10.0.0-beta.26_@svta+cml-cta@1.0.6__@svta+cml-structured-field-values@1.1.3___@svta+cml-utils@1.5.0__@svta+cml-utils@1.5.0_@svta+cml-structured-field-values@1.1.3__@svta+cml-utils@1.5.0_@svta+cml-utils@1.5.0": {
-      "integrity": "sha512-H6mdYfsDJ0Kei599TdDG/gJ2vgx46dUHnuH8jhW4cDAdjzvL9qFKp/0XaKAgsfMfKAFot/r2MqYDsUhCIBUq4g==",
-      "dependencies": [
-        "@videojs/spf",
-        "@videojs/utils",
-        "@vimeo/player",
-        "dashjs",
-        "hls.js",
-        "mux-embed"
-      ]
-    },
-    "@videojs/spf@10.0.0-beta.26": {
-      "integrity": "sha512-/yrmy3fulSJd2owJ+RSiYWVGROu0uRcElGsqmTTXi050cWEI7Wk7vC+ve1zlCFyAB+9on9XDUvwy/G6QO8k9ww==",
-      "dependencies": [
-        "@videojs/utils",
-        "signal-polyfill"
-      ]
-    },
-    "@videojs/store@10.0.0-beta.26_@videojs+element@10.0.0-beta.26": {
-      "integrity": "sha512-TaeP+dMCiVWDoBxOSp/t93v06Wy3J1tDBb2noZIAijStEbSIiSKYo+K7qEnArqTpsEA/bRphN4fEQBXmWYwpWw==",
-      "dependencies": [
-        "@videojs/element",
-        "@videojs/utils"
-      ],
-      "optionalPeers": [
-        "@videojs/element"
-      ]
-    },
-    "@videojs/utils@10.0.0-beta.26": {
-      "integrity": "sha512-XnbgF7O4ejOdKCKhakAHTGWUHTajzoxQlTM7kIGjfcCeoa8gmEb7V8cNue35FwCvBunw6JwM+4hqJQIPzOmUNQ=="
-    },
-    "@vimeo/player@2.30.4": {
-      "integrity": "sha512-M8m1UAhJSb+KCWuXDLWHViwj+3YY/0ogwFquRfMHs9e9LYjXT9iB7n+sOCKwUusbiXuU2HKmXx+FEGHtYZfUSg==",
-      "dependencies": [
-        "native-promise-only",
-        "weakmap-polyfill"
       ]
     },
     "@vitest/coverage-v8@4.1.10_vitest@4.1.10_happy-dom@20.11.1_vite@8.2.0": {
@@ -372,9 +233,6 @@
         "js-tokens"
       ]
     },
-    "bcp-47-match@2.0.3": {
-      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ=="
-    },
     "buffer-image-size@0.6.4": {
       "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
       "dependencies": [
@@ -384,30 +242,8 @@
     "chai@6.2.2": {
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="
     },
-    "codem-isoboxer@0.3.10": {
-      "integrity": "sha512-eNk3TRV+xQMJ1PEj0FQGY8KD4m0GPxT487XJ+Iftm7mVa9WpPFDMWqPt+46buiP5j5Wzqe5oMIhqBcAeKfygSA=="
-    },
     "convert-source-map@2.0.0": {
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
-    },
-    "dashjs@5.2.0_@svta+cml-cta@1.0.6__@svta+cml-structured-field-values@1.1.3___@svta+cml-utils@1.5.0__@svta+cml-utils@1.5.0_@svta+cml-structured-field-values@1.1.3__@svta+cml-utils@1.5.0_@svta+cml-utils@1.5.0": {
-      "integrity": "sha512-2W2KHFN53Sk7+rtdnIfSUK/3Oov+hraMTeVZwDOTSCNKM1cQtFiJdblNzRMnl59a/QDseG7JW+PC9mh/B+CMcg==",
-      "dependencies": [
-        "@svta/cml-608",
-        "@svta/cml-cmcd",
-        "@svta/cml-cmsd",
-        "@svta/cml-dash",
-        "@svta/cml-id3",
-        "@svta/cml-request",
-        "@svta/cml-xml",
-        "bcp-47-match",
-        "codem-isoboxer",
-        "fast-deep-equal",
-        "html-entities",
-        "imsc",
-        "localforage",
-        "path-browserify"
-      ]
     },
     "detect-libc@2.1.2": {
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
@@ -426,9 +262,6 @@
     },
     "expect-type@1.4.0": {
       "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="
-    },
-    "fast-deep-equal@3.1.3": {
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fdir@6.5.0_picomatch@4.0.5": {
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
@@ -459,23 +292,8 @@
     "has-flag@4.0.0": {
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
-    "hls.js@1.6.16": {
-      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA=="
-    },
-    "html-entities@2.6.0": {
-      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="
-    },
     "html-escaper@2.0.2": {
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
-    },
-    "immediate@3.0.6": {
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
-    },
-    "imsc@1.1.5": {
-      "integrity": "sha512-V8je+CGkcvGhgl2C1GlhqFFiUOIEdwXbXLiu1Fcubvvbo+g9inauqT3l0pNYXGoLPBj3jxtZz9t+wCopMkwadQ==",
-      "dependencies": [
-        "sax"
-      ]
     },
     "istanbul-lib-coverage@3.2.2": {
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="
@@ -497,12 +315,6 @@
     },
     "js-tokens@10.0.0": {
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="
-    },
-    "lie@3.1.1": {
-      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-      "dependencies": [
-        "immediate"
-      ]
     },
     "lightningcss-android-arm64@1.33.0": {
       "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
@@ -578,12 +390,6 @@
         "lightningcss-win32-x64-msvc"
       ]
     },
-    "localforage@1.10.0": {
-      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-      "dependencies": [
-        "lie"
-      ]
-    },
     "magic-string@0.30.21": {
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dependencies": [
@@ -604,21 +410,12 @@
         "semver"
       ]
     },
-    "mux-embed@5.18.1": {
-      "integrity": "sha512-ePsHjiEKY+FgrSBiMmaF+LOtTQSSBWv/1zqpREQFN96JE93xlsArT/MEi30yKOE06MgjOlL70YI750molu3y7g=="
-    },
-    "nanoid@3.3.16": {
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+    "nanoid@3.3.17": {
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "bin": true
-    },
-    "native-promise-only@0.8.1": {
-      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg=="
     },
     "obug@2.1.4": {
       "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="
-    },
-    "path-browserify@1.0.1": {
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "pathe@2.0.3": {
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
@@ -661,18 +458,12 @@
       ],
       "bin": true
     },
-    "sax@1.2.1": {
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
-    },
     "semver@7.8.5": {
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "bin": true
     },
     "siginfo@2.0.0": {
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
-    },
-    "signal-polyfill@0.2.2": {
-      "integrity": "sha512-p63Y4Er5/eMQ9RHg0M0Y64NlsQKpiu6MDdhBXpyywRuWiPywhJTpKJ1iB5K2hJEbFZ0BnDS7ZkJ+0AfTuL37Rg=="
     },
     "source-map-js@1.2.1": {
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
@@ -714,6 +505,7 @@
         "lightningcss",
         "picomatch",
         "postcss",
+        "rolldown",
         "tinyglobby"
       ],
       "optionalDependencies": [
@@ -753,9 +545,6 @@
       ],
       "bin": true
     },
-    "weakmap-polyfill@2.0.4": {
-      "integrity": "sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw=="
-    },
     "whatwg-mimetype@3.0.0": {
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
     },
@@ -767,13 +556,12 @@
       ],
       "bin": true
     },
-    "ws@8.21.1": {
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="
+    "ws@8.21.2": {
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="
     }
   },
   "workspace": {
     "dependencies": [
-      "npm:@videojs/html@10.0.0-beta.26",
       "npm:@vitest/coverage-v8@4.1.10",
       "npm:happy-dom@20.11.1",
       "npm:rolldown@1.2.3",

--- a/js/extensions/media.ts
+++ b/js/extensions/media.ts
@@ -1,9 +1,20 @@
-import '@videojs/html/video/player';
-import '@videojs/html/video/minimal-skin';
-
 import type { Disposer } from './types.ts';
 
 const VIDEO_RESTART_OFFSET = 0.2;
+const VIDEOJS_CDN = 'https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video-minimal.js';
+
+const loadVideojs = (): void => {
+  if (document.querySelector(`script[src="${VIDEOJS_CDN}"]`)) {
+    return;
+  }
+
+  const script = document.createElement('script');
+
+  script.type = 'module';
+  script.src = VIDEOJS_CDN;
+
+  document.head.append(script);
+};
 
 const onVideoEnded = (ev: Event): void => {
   (ev.currentTarget as HTMLVideoElement).currentTime = VIDEO_RESTART_OFFSET;
@@ -19,7 +30,7 @@ const setupMedia =
 
       const video = entry.target as HTMLVideoElement;
 
-      video.poster = video.dataset['poster' as keyof DOMStringMap] || video.poster || '';
+      video.poster = video.dataset['poster'] || video.poster || '';
 
       // Most of the videos on this site start with a fade-in,
       // so unless you intentionally shift the starting position, they are all black...!
@@ -38,6 +49,8 @@ export const initialize = (html: HTMLElement): Disposer => {
   if (videos.length === 0) {
     return () => {}; // no-op dispose
   }
+
+  loadVideojs();
 
   const ac = new AbortController();
   const obs = new IntersectionObserver(setupMedia(ac.signal), {


### PR DESCRIPTION
refs: #853

We will change the way we bundle `video.js` from a custom bundle to the official CDN entry point.
Although it’s still unclear whether we’ll continue using this method in the future, let’s give it a try!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Media playback now loads Video.js dynamically from the CDN when needed.
  - Improved handling prevents duplicate Video.js loads when multiple media elements are present.
  - Media observation begins after Video.js is ready, providing more reliable initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->