### PR TITLE
refactor(media): Retrieve only the parts that differ from the cache 💿

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 *.avif filter=lfs diff=lfs merge=lfs -text
+*.jxl filter=lfs diff=lfs merge=lfs -text
 *.mp3 filter=lfs diff=lfs merge=lfs -text
 *.webm filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
 
-tmp/*.avif -filter -diff -merge -text
+tmp/** -filter -diff -merge -text

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -64,25 +64,6 @@ jobs:
         run: |
           echo "cache-key=${{ hashFiles('src/**/*.avif', 'src/**/*.jxl', 'src/**/*.mp3', 'src/**/*.webm', 'src/**/*.webp') }}" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Git LFS Cache
-        id: cache-lfs
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: .git/lfs
-          key: lfs-${{ steps.set-cache-key.outputs.cache-key }}
-          restore-keys: |
-            lfs-
-
-      - name: Pull LFS Files
-        run: |
-          git lfs pull --include="src/**/*.avif,src/**/*.jxl,src/**/*.mp3,src/**/*.webm,src/**/*.webp"
-
-      - name: Save Git LFS Cache
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: .git/lfs
-          key: lfs-${{ steps.set-cache-key.outputs.cache-key }}
-
       - name: Restore Media Cache
         id: cache-media
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -91,6 +72,27 @@ jobs:
           key: media-${{ steps.set-cache-key.outputs.cache-key }}
           restore-keys: |
             media-
+
+      - name: Restore Git LFS Cache
+        if: steps.cache-media.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: .git/lfs
+          key: lfs-${{ steps.set-cache-key.outputs.cache-key }}
+          restore-keys: |
+            lfs-
+
+      - name: Pull LFS Files
+        if: steps.cache-media.outputs.cache-hit != 'true'
+        run: |
+          git lfs pull --include="src/**/*.avif,src/**/*.jxl,src/**/*.mp3,src/**/*.webm,src/**/*.webp"
+
+      - name: Save Git LFS Cache
+        if: steps.cache-media.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: .git/lfs
+          key: lfs-${{ steps.set-cache-key.outputs.cache-key }}
 
       - name: Synchronize Media Files
         if: steps.cache-media.outputs.cache-hit != 'true'
@@ -112,7 +114,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: tmp-media
-          key: ${{ steps.set-cache-key.outputs.cache-key }}
+          key: media-${{ steps.set-cache-key.outputs.cache-key }}
 
   test-wasm:
     name: Test Wasm

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -443,7 +443,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Remove LFS Pointer
-        run: find src -type f \( -name '*.avif' -o -name '*.webp' -o -name '*.webm' -o -name '*.mp3' \) -delete
+        run: find src -type f \( -name '*.avif' -o -name '*.jxl' -o -name '*.mp3' -o -name '*.webp' -o -name '*.webm' \) -delete
 
       - name: Populate Media Files
         run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -62,7 +62,17 @@ jobs:
       - name: Set Cache Key
         id: set-cache-key
         run: |
-          echo "cache-key=${{ hashFiles('src/**/*.avif', 'src/**/*.jxl', 'src/**/*.mp3', 'src/**/*.webm', 'src/**/*.webp') }}" >> "$GITHUB_OUTPUT"
+          digest=$(
+            git ls-files -s -z -- \
+              'src/*.avif' 'src/**/*.avif' \
+              'src/*.jxl' 'src/**/*.jxl' \
+              'src/*.mp3' 'src/**/*.mp3' \
+              'src/*.webm' 'src/**/*.webm' \
+              'src/*.webp' 'src/**/*.webp' |
+            sha256sum |
+            cut -d' ' -f1
+          )
+          echo "cache-key=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Restore Media Cache (allow partial match)
         id: cache-media

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -49,7 +49,6 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     outputs:
       cache-key: ${{ steps.set-cache-key.outputs.cache-key }}
-      cache-match: ${{ steps.check-match.outputs.match }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -63,48 +62,54 @@ jobs:
       - name: Set Cache Key
         id: set-cache-key
         run: |
-          echo "cache-key=media-${{ hashFiles('src/**/*.avif', 'src/**/*.webp', 'src/**/*.webm', 'src/**/*.mp3') }}" >> $GITHUB_OUTPUT
+          echo "cache-key=media-${{ hashFiles('src/**/*.avif', 'src/**/*.jxl', 'src/**/*.mp3', 'src/**/*.webm', 'src/**/*.webp') }}" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Media Cache (allow partial match)
-        id: cache-source
+      - name: Restore Git LFS Cache
+        id: cache-lfs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: .git/lfs
+          key: lfs-${{ github.sha }}
+          restore-keys: |
+            lfs-
+
+      - name: Pull LFS Files
+        run: |
+          git lfs pull --include="src/**/*.avif,src/**/*.jxl,src/**/*.mp3,src/**/*.webm,src/**/*.webp"
+
+      - name: Save Git LFS Cache
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: .git/lfs
+          key: lfs-${{ github.sha }}
+
+      - name: Restore Media Cache
+        id: cache-media
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: tmp-media
           key: ${{ steps.set-cache-key.outputs.cache-key }}
-          restore-keys: media-
-
-      - name: Verify Exact Cache Match
-        id: check-match
-        run: |
-          if [ "${{ steps.cache-source.outputs.cache-hit }}" = "true" ] && \
-             [ "${{ steps.cache-source.outputs.cache-matched-key }}" = "${{ steps.set-cache-key.outputs.cache-key }}" ]; then
-            echo "match=true" >> $GITHUB_OUTPUT
-          else
-            echo "match=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Pull Missing LFS Files (on partial or miss)
-        if: steps.check-match.outputs.match != 'true'
-        run: |
-          git lfs pull --include="src/**/*.avif,src/**/*.webp,src/**/*.webm,src/**/*.mp3"
+          restore-keys: |
+            media-
 
       - name: Synchronize Media Files
-        if: steps.check-match.outputs.match != 'true'
+        if: steps.cache-media.outputs.cache-hit != 'true'
         run: |
           rm -rf tmp-media
           mkdir -p tmp-media
           rsync -a --delete \
             --include='*/' \
             --include='*.avif' \
-            --include='*.webp' \
-            --include='*.webm' \
+            --include='*.jxl' \
             --include='*.mp3' \
+            --include='*.webm' \
+            --include='*.webp' \
             --exclude='*' \
             src/ tmp-media
 
-      - name: Save Media Cache (new primary key)
-        if: steps.check-match.outputs.match != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      - name: Save Media Cache
+        if: steps.cache-media.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8346c3cc7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: tmp-media
           key: ${{ steps.set-cache-key.outputs.cache-key }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Save Media Cache
         if: steps.cache-media.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8346c3cc7cc4c66a329aec7e433d2d1c52a9 # v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: tmp-media
           key: ${{ steps.set-cache-key.outputs.cache-key }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           echo "cache-key=${{ hashFiles('src/**/*.avif', 'src/**/*.jxl', 'src/**/*.mp3', 'src/**/*.webm', 'src/**/*.webp') }}" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Media Cache
+      - name: Restore Media Cache (allow partial match)
         id: cache-media
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -441,7 +441,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: tmp-media
-          key: ${{ needs.cache-media-files.outputs.cache-key }}
+          key: media-${{ needs.cache-media-files.outputs.cache-key }}
           fail-on-cache-miss: true
 
       - name: Remove LFS Pointer

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -62,14 +62,14 @@ jobs:
       - name: Set Cache Key
         id: set-cache-key
         run: |
-          echo "cache-key=media-${{ hashFiles('src/**/*.avif', 'src/**/*.jxl', 'src/**/*.mp3', 'src/**/*.webm', 'src/**/*.webp') }}" >> "$GITHUB_OUTPUT"
+          echo "cache-key=${{ hashFiles('src/**/*.avif', 'src/**/*.jxl', 'src/**/*.mp3', 'src/**/*.webm', 'src/**/*.webp') }}" >> "$GITHUB_OUTPUT"
 
       - name: Restore Git LFS Cache
         id: cache-lfs
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .git/lfs
-          key: lfs-${{ github.sha }}
+          key: lfs-${{ steps.set-cache-key.outputs.cache-key }}
           restore-keys: |
             lfs-
 
@@ -81,14 +81,14 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .git/lfs
-          key: lfs-${{ github.sha }}
+          key: lfs-${{ steps.set-cache-key.outputs.cache-key }}
 
       - name: Restore Media Cache
         id: cache-media
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: tmp-media
-          key: ${{ steps.set-cache-key.outputs.cache-key }}
+          key: media-${{ steps.set-cache-key.outputs.cache-key }}
           restore-keys: |
             media-
 


### PR DESCRIPTION
This pull request improves the logic so that `git lfs pull` retrieves only media files that have been added or modified.
(I thought I had already implemented this logic, but it wasn't working at all!)

Since we're almost at the `lfs` bandwidth limit, I can't run it here, but please let me know if the code doesn't seem to be working as intended!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `.jxl` media files in publishing, asset handling, and caching.
  * Improved media caching for JPEG XL, WebP, AVIF, MP3, and WebM files.

* **Bug Fixes**
  * Improved restoration and synchronization of cached media during site deployments.
  * Added Git LFS caching for supported media files.
  * Expanded temporary-file exclusions to prevent unintended files from being included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->