### PR TITLE
refactor(search): move search result rendering to a `Custom Element` 🍮

### DIFF
--- a/js/searchResult.ts
+++ b/js/searchResult.ts
@@ -78,7 +78,7 @@ export class SearchResult extends HTMLElement {
       return;
     }
 
-    const url = new URL(href);
+    const url = new URL(href, document.baseURI);
 
     if (checkURL(url)) {
       updateMark();

--- a/js/searchResult.ts
+++ b/js/searchResult.ts
@@ -126,12 +126,7 @@ export class SearchResult extends HTMLElement {
         ev.preventDefault();
         this.moveFocus(this.nextElementSibling);
         break;
-      /*
-      case "ArrowUp":
-        ev.preventDefault();
-        this.moveFocus(this.previousElementSibling);
-        break;
-      */
+
       case 'ArrowUp': {
         ev.preventDefault();
 

--- a/js/searchResult.ts
+++ b/js/searchResult.ts
@@ -1,0 +1,164 @@
+import { updateMark } from './mark.ts';
+import { focusSearchBar, getSearchPopElement, hiddenSearch } from './searcher.ts';
+
+import { setHTML } from './utils/html-sanitizer.ts';
+
+let currentForcus: SearchResult | null = null;
+
+// Fonts used in the score bar
+const SCORE_BAR_CHARACTER = '▰';
+// Rate used to calculate the length of the scorebar
+const SCORE_BAR_RATE = 8;
+// Maximum value displayed on the score bar (does not affect the actual score)
+const SCORE_BAR_MAX = 256;
+
+const createScoreElement = (score: number): HTMLDivElement => {
+  const element = document.createElement('div');
+
+  element.className = 'score';
+  element.role = 'meter';
+  element.ariaLabel = `score:${score}pt`;
+
+  element.textContent = `${SCORE_BAR_CHARACTER.repeat(
+    Math.floor(Math.min(score, SCORE_BAR_MAX) / SCORE_BAR_RATE),
+  )} (${score}pt)`;
+
+  return element;
+};
+
+const checkURL = (url: URL): boolean =>
+  url.origin + url.pathname === globalThis.location.origin + globalThis.location.pathname;
+
+export class SearchResult extends HTMLElement {
+  connectedCallback(): void {
+    this.tabIndex = 0;
+    this.role = 'option';
+
+    this.render();
+
+    this.addEventListener('keydown', this.handleKeydown, {
+      passive: false,
+    });
+
+    this.addEventListener('click', this.handleClick, {
+      passive: true,
+    });
+  }
+
+  private render(): void {
+    const page = this.dataset['page'];
+    const label = this.dataset['label'];
+    const score = this.dataset['score'];
+
+    if (page === undefined || score === undefined || label === undefined) {
+      console.warn('SearchResult#render: invalid data');
+      return;
+    }
+
+    const excerpt = document.createElement('span');
+    excerpt.className = 'excerpt';
+    setHTML(excerpt, this.innerHTML);
+
+    const pageElement = document.createElement('span');
+    pageElement.className = 'label';
+    pageElement.textContent = label;
+
+    this.replaceChildren(pageElement, excerpt, createScoreElement(Number(score)));
+
+    this.ariaLabel = `${page} ${score}pt`;
+  }
+
+  private open(): void {
+    const href = this.dataset['href'];
+
+    if (href === undefined) {
+      return;
+    }
+
+    const url = new URL(href);
+
+    if (checkURL(url)) {
+      updateMark();
+    }
+
+    navigation.navigate(url);
+
+    requestAnimationFrame(() => {
+      hiddenSearch();
+    });
+  }
+
+  private updateFocus(): boolean {
+    if (currentForcus === this) {
+      return false;
+    }
+
+    if (currentForcus !== null) {
+      currentForcus.ariaSelected = null;
+    }
+    this.ariaSelected = 'true';
+
+    const pop = getSearchPopElement();
+
+    if (pop !== null) {
+      pop.ariaActiveDescendantElement = this;
+    }
+
+    currentForcus = this;
+    return true;
+  }
+
+  private moveFocus(elm: Element | null): void {
+    if (!(elm instanceof SearchResult)) {
+      return;
+    }
+
+    elm.focus();
+    elm.updateFocus();
+  }
+
+  private handleKeydown(ev: KeyboardEvent): void {
+    switch (ev.key) {
+      case 'ArrowDown':
+        ev.preventDefault();
+        this.moveFocus(this.nextElementSibling);
+        break;
+      /*
+      case "ArrowUp":
+        ev.preventDefault();
+        this.moveFocus(this.previousElementSibling);
+        break;
+      */
+      case 'ArrowUp': {
+        ev.preventDefault();
+
+        const previous = this.previousElementSibling;
+
+        if (previous !== null) {
+          this.moveFocus(previous);
+        } else {
+          focusSearchBar();
+        }
+
+        break;
+      }
+
+      case 'Enter':
+        this.open();
+        break;
+    }
+  }
+
+  private handleClick(): void {
+    if (this.updateFocus()) {
+      return;
+    }
+
+    this.open();
+  }
+
+  public focusAndSelect(): void {
+    this.focus();
+    this.updateFocus();
+  }
+}

--- a/js/searchResult.ts
+++ b/js/searchResult.ts
@@ -18,6 +18,9 @@ const createScoreElement = (score: number): HTMLDivElement => {
   element.className = 'score';
   element.role = 'meter';
   element.ariaLabel = `score:${score}pt`;
+  element.ariaValueNow = String(score);
+  element.ariaValueMin = '0';
+  element.ariaValueMax = String(SCORE_BAR_MAX);
 
   element.textContent = `${SCORE_BAR_CHARACTER.repeat(
     Math.floor(Math.min(score, SCORE_BAR_MAX) / SCORE_BAR_RATE),

--- a/js/searchResult.ts
+++ b/js/searchResult.ts
@@ -3,7 +3,7 @@ import { focusSearchBar, getSearchPopElement, hiddenSearch } from './searcher.ts
 
 import { setHTML } from './utils/html-sanitizer.ts';
 
-let currentForcus: SearchResult | null = null;
+let currentFocus: SearchResult | null = null;
 
 // Fonts used in the score bar
 const SCORE_BAR_CHARACTER = '▰';
@@ -92,12 +92,12 @@ export class SearchResult extends HTMLElement {
   }
 
   private updateFocus(): boolean {
-    if (currentForcus === this) {
+    if (currentFocus === this) {
       return false;
     }
 
-    if (currentForcus !== null) {
-      currentForcus.ariaSelected = null;
+    if (currentFocus !== null) {
+      currentFocus.ariaSelected = null;
     }
     this.ariaSelected = 'true';
 
@@ -107,7 +107,7 @@ export class SearchResult extends HTMLElement {
       pop.ariaActiveDescendantElement = this;
     }
 
-    currentForcus = this;
+    currentFocus = this;
     return true;
   }
 

--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -67,7 +67,8 @@ export const hiddenSearch = (): void => {
   elmPop.hidePopover();
   elmSearch.ariaExpanded = 'false';
 
-  searchAbort.abort();
+  searchAbort?.abort();
+  searchAbort = null;
 };
 
 const closedPopover = (ev: Event): void => {

--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -1,5 +1,5 @@
 import { ROOT_PATH } from './constants.ts';
-import { updateMark } from './mark.ts';
+import { SearchResult } from './searchResult.ts';
 
 import { loadStyleSheet } from './utils/css-loader.ts';
 import { fetchAndDecompress } from './utils/fetch.ts';
@@ -32,13 +32,16 @@ let elmHeader: HTMLElement;
 let elmResults: HTMLElement;
 
 let finder: Finder;
-
-let focusedLi: Element | null;
-
 let searchAbort: AbortController;
 
+export const getSearchPopElement = (): HTMLElement | null => document.getElementById(POP_ID);
+
 // NOTE: I'd rather not, but I have to use `getElementById` every time.
-export const isSearchPopoverOpen = (): boolean => document.getElementById(POP_ID)?.matches(':popover-open') ?? false;
+export const isSearchPopoverOpen = (): boolean => getSearchPopElement()?.matches(':popover-open') ?? false;
+
+export const focusSearchBar = (): void => {
+  elmSearchBar.focus();
+};
 
 const showResults = (): void => {
   const bytes = finder.search(elmSearchBar.value);
@@ -60,73 +63,11 @@ const showResults = (): void => {
   setHTML(elmResults, new TextDecoder().decode(bytes.subarray(htmlStart, htmlEnd)));
 };
 
-const checkURL = (url: URL): boolean =>
-  url.origin + url.pathname === globalThis.location.origin + globalThis.location.pathname;
-
-const hiddenSearch = (): void => {
+export const hiddenSearch = (): void => {
   elmPop.hidePopover();
   elmSearch.ariaExpanded = 'false';
 
   searchAbort.abort();
-};
-
-const jumpUrl = (): void => {
-  const aElement = focusedLi?.querySelector('a') as HTMLAnchorElement;
-
-  if (!aElement) {
-    return;
-  }
-
-  const url = new URL(aElement.href);
-
-  if (checkURL(url)) {
-    updateMark();
-  }
-
-  navigation.navigate(url);
-
-  requestAnimationFrame(() => {
-    hiddenSearch();
-  });
-};
-
-const updateFocus = (target: HTMLElement): void => {
-  const li = target.closest('li');
-
-  if (!li || focusedLi === li) {
-    return;
-  }
-
-  if (focusedLi) {
-    focusedLi.ariaSelected = null;
-  }
-  li.ariaSelected = 'true';
-
-  if (target) {
-    elmPop.ariaActiveDescendantElement = target;
-  }
-  focusedLi = li;
-};
-
-const popupFocus = (ev: KeyboardEvent): void => {
-  if (ev.key !== 'Enter') {
-    updateFocus(ev.target as HTMLElement);
-    return;
-  }
-
-  jumpUrl();
-};
-
-const searchMouseupHandler = (ev: MouseEvent): void => {
-  const prevFocused = focusedLi;
-
-  updateFocus(ev.target as HTMLElement);
-
-  if (prevFocused !== focusedLi) {
-    return;
-  }
-
-  jumpUrl();
 };
 
 const closedPopover = (ev: Event): void => {
@@ -138,6 +79,21 @@ const closedPopover = (ev: Event): void => {
 };
 
 const debounceSearchInput = debounce((_: Event) => showResults(), DEBOUNCE_DELAY_MS);
+
+const searchbarKeydown = (ev: KeyboardEvent): void => {
+  if (ev.key !== 'ArrowDown') {
+    return;
+  }
+
+  const result = elmResults.querySelector('search-result');
+
+  if (!(result instanceof SearchResult)) {
+    return;
+  }
+
+  ev.preventDefault();
+  result.focusAndSelect();
+};
 
 const showSearch = (): void => {
   if (isSearchPopoverOpen()) {
@@ -157,15 +113,11 @@ const showSearch = (): void => {
     signal,
   });
 
-  elmResults.addEventListener('keyup', popupFocus, {
-    passive: true,
+  elmSearchBar.addEventListener('keydown', searchbarKeydown, {
+    passive: false,
     signal,
   });
 
-  elmPop.addEventListener('click', searchMouseupHandler, {
-    passive: true,
-    signal,
-  });
   elmPop.addEventListener('toggle', closedPopover, {
     passive: true,
     signal,
@@ -229,6 +181,8 @@ const bootSearch = async (): Promise<void> => {
       throw new Error('Missing required search data fields');
     }
 
+    customElements.define('search-result', SearchResult);
+
     await wasmPromise;
     finder = new Finder(ROOT_PATH, data.doc_urls, data.index.documentStore.docs);
 
@@ -261,7 +215,10 @@ export const startupSearch = (): void => {
   }
   elmSearch = button;
 
-  elmSearch.addEventListener('click', bootSearch, { once: true, passive: true });
+  elmSearch.addEventListener('click', bootSearch, {
+    once: true,
+    passive: true,
+  });
 
   document.addEventListener('keyup', bootSearchFromKey, {
     passive: true,

--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -32,7 +32,7 @@ let elmHeader: HTMLElement;
 let elmResults: HTMLElement;
 
 let finder: Finder;
-let searchAbort: AbortController;
+let searchAbort: AbortController | null;
 
 export const getSearchPopElement = (): HTMLElement | null => document.getElementById(POP_ID);
 

--- a/js/serviceworker.ts
+++ b/js/serviceworker.ts
@@ -1,6 +1,6 @@
 declare const self: ServiceWorkerGlobalScope;
 
-const CACHE_VERSION = 'v11.10.0';
+const CACHE_VERSION = 'v11.11.0';
 
 const CACHE_URL = '/commentary/';
 const FALLBACK_IMAGE = 'favicon.png';

--- a/rs/wasm/Cargo.lock
+++ b/rs/wasm/Cargo.lock
@@ -33,9 +33,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -417,7 +417,7 @@ checksum = "33ff1c1b360982e93b6d8ea9c04836f71dba0817a16f91e229cf3a51bdd9d987"
 
 [[package]]
 name = "wasm-book"
-version = "1.5.4"
+version = "2.0.0"
 dependencies = [
  "bumpalo",
  "getset",

--- a/rs/wasm/Cargo.lock
+++ b/rs/wasm/Cargo.lock
@@ -421,7 +421,6 @@ version = "2.0.0"
 dependencies = [
  "bumpalo",
  "getset",
- "itoa",
  "js-sys",
  "macros",
  "memchr",

--- a/rs/wasm/Cargo.toml
+++ b/rs/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-book"
-version = "1.5.4"
+version = "2.0.0"
 authors = ["CoralPink <teqt6ytqt@mozmail.com>"]
 edition = "2024"
 rust-version = "1.88"

--- a/rs/wasm/Cargo.toml
+++ b/rs/wasm/Cargo.toml
@@ -3,7 +3,7 @@ name = "wasm-book"
 version = "2.0.0"
 authors = ["CoralPink <teqt6ytqt@mozmail.com>"]
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.98"
 description = "This is the WebAssembly code used on this site."
 homepage = "https://github.com/CoralPink"
 repository = "https://github.com/CoralPink/commentary"
@@ -25,7 +25,6 @@ panic = "abort"
 [dependencies]
 bumpalo = { version = "=3.20.3", features = ["collections"] }
 getset = "=0.1.7"
-itoa = "=1.0.18"
 js-sys = "=0.3.104"
 macros = { path = "macros" }
 memchr = { version = "=2.8.3", default-features = false }

--- a/rs/wasm/src/searcher/constants.rs
+++ b/rs/wasm/src/searcher/constants.rs
@@ -19,12 +19,5 @@ pub const SCORE_HEADER_LENGTH_DECAY_EXPONENT: f32 = 0.4;
 /// Number of words considered for teaser/highlight calculation.
 pub const TEASER_WORD_COUNT: usize = 256;
 
-/// Fonts used in the score bar
-pub const SCORE_BAR_CHARACTER: &str = "▰";
-/// Rate used to calculate the length of the scorebar
-pub const SCORE_BAR_RATE: usize = 8;
-/// Maximum value displayed on the score bar (does not affect the actual score)
-pub const SCORE_BAR_MAX: usize = 256;
-
 /// Estimated maximum number of tokens for a single document.
 pub const EXCERPT_TOKENS_MAX: usize = 24;

--- a/rs/wasm/src/searcher/html_builder.rs
+++ b/rs/wasm/src/searcher/html_builder.rs
@@ -1,6 +1,7 @@
 use crate::searcher::excerpt::{compute_window_from_ranges, get_hitranges};
 use crate::searcher::hit_list::{Hit, HitList};
 
+use core::fmt::NumBuffer;
 use memchr::{memchr2, memchr3};
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 
@@ -52,14 +53,14 @@ struct SearchHit<'a> {
 
 pub struct HtmlBuilder {
     buf: Vec<u8>,
-    itoa: itoa::Buffer,
+    num_buf: NumBuffer<usize>,
 }
 
 impl HtmlBuilder {
     pub fn new_for_results(count: usize) -> Self {
         Self {
             buf: Vec::with_capacity(count * BUFFER_HTML_MAGNIFICATION),
-            itoa: itoa::Buffer::new(),
+            num_buf: NumBuffer::new(),
         }
     }
 
@@ -178,7 +179,7 @@ impl HtmlBuilder {
         self.buf.push(b' ');
         self.buf.extend_from_slice(name.as_bytes());
         self.buf.extend_from_slice(b"=\"");
-        self.buf.extend_from_slice(self.itoa.format(value).as_bytes());
+        self.buf.extend_from_slice(value.format_into(&mut self.num_buf).as_bytes());
         self.buf.push(b'"');
     }
 

--- a/rs/wasm/src/searcher/html_builder.rs
+++ b/rs/wasm/src/searcher/html_builder.rs
@@ -1,4 +1,3 @@
-use crate::searcher::constants::*;
 use crate::searcher::excerpt::{compute_window_from_ranges, get_hitranges};
 use crate::searcher::hit_list::{Hit, HitList};
 
@@ -14,9 +13,6 @@ const RESULT_DATA_OFFSET: usize = LENGTH_FIELD_SIZE * 2;
 
 /// Buffer size multiplier for 1 search result
 const BUFFER_HTML_MAGNIFICATION: usize = 1024;
-
-/// Convert the text for the score bar defined in `constants.rs` to the u8 type and store it
-const WRITE_SCORE_BAR_CHARACTER: &[u8] = SCORE_BAR_CHARACTER.as_bytes();
 
 /// HTML tag used to mark highlighted words.
 const MARK_TAG: &[u8] = "<mark>".as_bytes();
@@ -178,24 +174,12 @@ impl HtmlBuilder {
         self.buf.extend_from_slice(tag.as_bytes());
     }
 
-    fn attr(&mut self, key: &str, value: &str) {
-        self.buf.push(b' ');
-        self.buf.extend_from_slice(key.as_bytes());
-        self.buf.extend_from_slice(b"=\"");
-        self.safe_text(value);
-        self.buf.push(b'"');
-    }
-
     fn attr_num(&mut self, name: &str, value: usize) {
         self.buf.push(b' ');
         self.buf.extend_from_slice(name.as_bytes());
         self.buf.extend_from_slice(b"=\"");
         self.buf.extend_from_slice(self.itoa.format(value).as_bytes());
         self.buf.push(b'"');
-    }
-
-    pub fn num(&mut self, value: usize) {
-        self.buf.extend_from_slice(self.itoa.format(value).as_bytes());
     }
 
     fn close_open(&mut self) {
@@ -223,60 +207,34 @@ impl HtmlBuilder {
         }
     }
 
-    fn score_bar(&mut self, score: usize) {
-        for _ in 0..std::cmp::min(score, SCORE_BAR_MAX) / SCORE_BAR_RATE {
-            self.buf.extend_from_slice(WRITE_SCORE_BAR_CHARACTER);
-        }
-    }
-
-    fn li_search_result(&mut self, hit: &SearchHit) {
+    fn search_result(&mut self, hit: &SearchHit) {
         let doc = hit.el.doc();
-        let score = hit.el.score;
 
-        self.open("li");
-        self.attr("tabindex", "0");
-        self.attr("role", "option");
-        self.attr_num("id", hit.el.id);
-        self.buf.extend_from_slice(b" aria-label=\"");
-        self.safe_text(hit.page);
-        self.buf.push(b' ');
-        self.num(score);
-        self.buf.extend_from_slice(b"pt\">");
+        self.open("search-result");
 
-        // link
-        self.open("a");
-        self.attr("tabindex", "-1");
-        self.buf.extend_from_slice(b" href=\"");
+        self.buf.extend_from_slice(b" data-href=\"");
         self.safe_text(hit.root_path);
         self.safe_text(hit.page);
         self.write_mark(hit.normalized_terms);
         self.buf.push(b'#');
         self.safe_text(hit.head);
-        self.buf.extend_from_slice(b"\">");
+        self.buf.push(b'"');
+
+        self.buf.extend_from_slice(b" data-page=\"");
+        self.safe_text(hit.page);
+        self.buf.push(b'"');
+
+        self.buf.extend_from_slice(b" data-label=\"");
         self.safe_text(doc.breadcrumbs());
-        self.end("a");
+        self.buf.push(b'"');
 
-        // excerpt
-        self.open("span");
-        self.attr("aria-hidden", "true");
+        self.attr_num("data-score", hit.el.score);
+
         self.close_open();
+
         self.write_highlighted_excerpt(doc.body(), hit.normalized_terms);
-        self.end("span");
 
-        // score
-        self.open("div");
-        self.attr("class", "score");
-        self.attr("role", "meter");
-        self.buf.extend_from_slice(b" aria-label=\"score:");
-        self.num(score);
-        self.buf.extend_from_slice(b"pt\">");
-        self.score_bar(score);
-        self.buf.extend_from_slice(b" (");
-        self.num(score);
-        self.buf.extend_from_slice(b"pt)");
-        self.end("div");
-
-        self.end("li");
+        self.end("search-result");
     }
 
     pub fn build_search_result(
@@ -292,7 +250,7 @@ impl HtmlBuilder {
             if let Some(url) = url_table.get(el.id) {
                 let (page, head) = parse_uri(url);
 
-                self.li_search_result(&SearchHit {
+                self.search_result(&SearchHit {
                     root_path,
                     page,
                     head,

--- a/scss/search.scss
+++ b/scss/search.scss
@@ -37,7 +37,7 @@
   ul {
     padding-left: 0.4rem;
 
-    li {
+    search-result {
       display: flex;
       flex-direction: column;
       gap: 0.4em;
@@ -54,17 +54,14 @@
         border-radius: 0.64rem
       }
 
-      a {
-        pointer-events: none;
-
+      .label{
         font-family: var.$italic-font;
         font-style: italic;
 
         color: var(--links);
-        text-decoration: none;
       }
 
-      span {
+      .excerpt {
         padding-left: 1em;
       }
 

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -102,7 +102,7 @@
       <input type="search" id="searchbar" name="searchbar" placeholder="Search this book ..." aria-controls="searchresults" aria-describedby="results-header">
 
       <div id="results-header" aria-live="polite"></div>
-      <ul id="searchresults"></ul>
+      <ul id="searchresults" role="listbox"></ul>
     </div>
 
     <script type="module" src="{{ resource "initialize.js"}}"></script>


### PR DESCRIPTION
The main objectives of this PR are as follows:

- Keep search and excerpt highlighting in WASM.
- Let the custom element handle DOM construction and presentation.

In conjunction with this, the following improvements will also be implemented.

- Add keyboard navigation between the search input and results.
- Support `ArrowUp` / `ArrowDown` navigation and `Enter` to open results.

This separates search processing from UI rendering and makes the search result interaction easier to manage 🔍

While I was writing this PR, I noticed that `Rust 1.98` had been released, so I updated the code to use `core::fmt::NumBuffer`. As a result, the MSRV will be updated to `1.98`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now display metadata, highlighted excerpts, and a visual relevance score.
  * Added keyboard and mouse navigation for selecting and opening results.
  * Focus returns to the search bar when navigating above the first result.

* **Accessibility**
  * Improved search-result semantics and focus management for assistive technologies.

* **Bug Fixes**
  * Search popover closing now handles interrupted interactions safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->