### PR TITLE
fix(#880): Set `aria-activedescendant` on `#searchbar` 🍫

### DIFF
--- a/js/searchHelper.ts
+++ b/js/searchHelper.ts
@@ -1,12 +1,23 @@
 const TARGET_SEARCH_BUTTON = 'search-btn';
 const TARGET_SEARCH_POP = 'search-pop';
+const TARGET_SEARCH_BAR = 'searchbar';
+const TARGET_RESULTS_HEADER = 'results-header';
+const TARGET_RESULTS_BODY = 'searchresults';
 
-export const getSearchButton = (): HTMLElement | null => document.getElementById(TARGET_SEARCH_BUTTON);
-export const getSearchPop = (): HTMLElement | null => document.getElementById(TARGET_SEARCH_POP);
+const requireElement = <T extends HTMLElement>(id: string): T => {
+  const elm = document.getElementById(id);
+
+  if (elm === null) {
+    throw new Error(`Element not found: #${id}`);
+  }
+  return elm as T;
+};
+
+export const getSearchButton = (): HTMLButtonElement => requireElement<HTMLButtonElement>(TARGET_SEARCH_BUTTON);
+export const getSearchPop = (): HTMLDivElement => requireElement<HTMLDivElement>(TARGET_SEARCH_POP);
+export const getSearchBar = (): HTMLInputElement => requireElement<HTMLInputElement>(TARGET_SEARCH_BAR);
+export const getResultsHeader = (): HTMLDivElement => requireElement<HTMLDivElement>(TARGET_RESULTS_HEADER);
+export const getResultsBody = (): HTMLUListElement => requireElement<HTMLUListElement>(TARGET_RESULTS_BODY);
 
 // NOTE: I'd rather not, but I have to use `getElementById` every time.
-export const isSearchPopoverOpen = (): boolean => getSearchPop()?.matches(':popover-open') ?? false;
-
-export const focusSearchBar = (): void => {
-  document.getElementById('searchbar')?.focus();
-};
+export const isSearchPopoverOpen = (): boolean => getSearchPop().matches(':popover-open') ?? false;

--- a/js/searchResult.ts
+++ b/js/searchResult.ts
@@ -1,5 +1,5 @@
 import { updateMark } from './mark.ts';
-import { focusSearchBar, getSearchPop } from './searchHelper.ts';
+import { getSearchBar } from './searchHelper.ts';
 
 import { setHTML } from './utils/html-sanitizer.ts';
 
@@ -100,11 +100,7 @@ export class SearchResult extends HTMLElement {
     this.ariaSelected = 'true';
     currentFocus = this;
 
-    const pop = getSearchPop();
-
-    if (pop !== null) {
-      pop.ariaActiveDescendantElement = this;
-    }
+    getSearchBar().ariaActiveDescendantElement = this;
 
     return true;
   }
@@ -133,9 +129,8 @@ export class SearchResult extends HTMLElement {
         if (previous !== null) {
           this.moveFocus(previous);
         } else {
-          focusSearchBar();
+          getSearchBar().focus();
         }
-
         break;
       }
 

--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -1,5 +1,5 @@
 import { ROOT_PATH } from './constants.ts';
-import { getSearchButton, getSearchPop, isSearchPopoverOpen } from './searchHelper.ts';
+import * as helper from './searchHelper.ts';
 import { SearchResult } from './searchResult.ts';
 
 import { loadStyleSheet } from './utils/css-loader.ts';
@@ -22,36 +22,34 @@ const RESULT_HEADER_LEN_POSITION = 0;
 const RESULT_HTML_LEN_POSITION = LENGTH_FIELD_SIZE * 1;
 const RESULT_DATA_START = LENGTH_FIELD_SIZE * 2;
 
-let elmSearchBar: HTMLInputElement;
-let elmHeader: HTMLElement;
-let elmResults: HTMLElement;
-
 let finder: Finder;
 let searchAbort: AbortController | null = null;
 
 const showResults = (): void => {
-  const bytes = finder.search(elmSearchBar.value);
+  const bytes = finder.search(helper.getSearchBar().value);
   const dv = new DataView(bytes.buffer);
 
   const headerLen = dv.getUint32(RESULT_HEADER_LEN_POSITION, true);
   const htmlLen = dv.getUint32(RESULT_HTML_LEN_POSITION, true);
 
-  elmHeader.textContent = new TextDecoder().decode(bytes.subarray(RESULT_DATA_START, RESULT_DATA_START + headerLen));
+  helper.getResultsHeader().textContent = new TextDecoder().decode(
+    bytes.subarray(RESULT_DATA_START, RESULT_DATA_START + headerLen),
+  );
 
   if (htmlLen === 0) {
-    elmResults.textContent = '';
+    helper.getResultsBody().textContent = '';
     return;
   }
 
   const htmlStart = RESULT_DATA_START + headerLen;
   const htmlEnd = htmlStart + htmlLen;
 
-  setHTML(elmResults, new TextDecoder().decode(bytes.subarray(htmlStart, htmlEnd)));
+  setHTML(helper.getResultsBody(), new TextDecoder().decode(bytes.subarray(htmlStart, htmlEnd)));
 };
 
 export const hiddenSearch = (): void => {
-  getSearchPop()?.hidePopover();
-  getSearchButton()!.ariaExpanded = 'false';
+  helper.getSearchPop().hidePopover();
+  helper.getSearchButton().ariaExpanded = 'false';
 
   if (searchAbort === null) {
     return;
@@ -71,11 +69,11 @@ const closedPopover = (ev: Event): void => {
 const debounceSearchInput = debounce((_: Event) => showResults(), DEBOUNCE_DELAY_MS);
 
 const searchbarKeydown = (ev: KeyboardEvent): void => {
-  if (ev.key !== 'ArrowDown') {
+  if (!(ev.key === 'ArrowDown' || ev.key === 'Enter')) {
     return;
   }
 
-  const result = elmResults.querySelector('search-result');
+  const result = helper.getResultsHeader().querySelector('search-result');
 
   if (!(result instanceof SearchResult)) {
     return;
@@ -86,19 +84,16 @@ const searchbarKeydown = (ev: KeyboardEvent): void => {
 };
 
 const showSearch = (): void => {
-  if (isSearchPopoverOpen()) {
+  if (helper.isSearchPopoverOpen()) {
     return;
   }
 
-  getSearchButton()!.ariaExpanded = 'true';
+  helper.getSearchButton()!.ariaExpanded = 'true';
 
-  const elmPop = getSearchPop();
-
-  if (elmPop === null) {
-    console.error('searcher: popup element not found');
-    return;
-  }
+  const elmPop = helper.getSearchPop();
   elmPop.showPopover();
+
+  const elmSearchBar = helper.getSearchBar();
   elmSearchBar.select();
 
   searchAbort = new AbortController();
@@ -142,32 +137,10 @@ const bootSearch = async (): Promise<void> => {
 
   document.removeEventListener('keyup', bootSearchFromKey);
 
-  const elements = {
-    searchBar: document.getElementById('searchbar'),
-    header: document.getElementById('results-header'),
-    results: document.getElementById('searchresults'),
-    button: getSearchButton(),
-  };
+  const button = helper.getSearchButton();
 
-  if (
-    elements.searchBar === null ||
-    elements.header === null ||
-    elements.results === null ||
-    elements.button === null
-  ) {
-    throw new Error('Required DOM elements not found');
-  }
-
-  if (!(elements.searchBar instanceof HTMLInputElement)) {
-    throw new Error('searchbar element is not an input element');
-  }
-
-  elmSearchBar = elements.searchBar;
-  elmHeader = elements.header;
-  elmResults = elements.results;
-
-  elements.button.removeEventListener('click', bootSearch);
-  elements.button.addEventListener('click', showSearch, {
+  button.removeEventListener('click', bootSearch);
+  button.addEventListener('click', showSearch, {
     passive: true,
   });
 
@@ -191,7 +164,7 @@ const bootSearch = async (): Promise<void> => {
     await cssPromise;
     showSearch();
   } catch (e: unknown) {
-    elements.button.style.display = 'none';
+    button.style.display = 'none';
 
     console.error(`Error during initialization: ${e}`);
     toast.error('Search is currently unavailable.');
@@ -209,14 +182,7 @@ const bootSearchFromKey = (ev: KeyboardEvent): void => {
 };
 
 export const startupSearch = (): void => {
-  const button = getSearchButton();
-
-  if (button === null) {
-    toast.error('Search is currently unavailable.');
-    return;
-  }
-
-  button.addEventListener('click', bootSearch, {
+  helper.getSearchButton().addEventListener('click', bootSearch, {
     once: true,
     passive: true,
   });

--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -73,7 +73,7 @@ const searchbarKeydown = (ev: KeyboardEvent): void => {
     return;
   }
 
-  const result = helper.getResultsHeader().querySelector('search-result');
+  const result = helper.getResultsBody().querySelector('search-result');
 
   if (!(result instanceof SearchResult)) {
     return;

--- a/js/test/searcher.test.ts
+++ b/js/test/searcher.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
 import { startupSearch } from '../searcher.ts';
-import { getSearchButton} from '../searchHelper.ts';
+import { getSearchButton } from '../searchHelper.ts';
 
 // Mock modules before imports
 vi.mock('../utils/css-loader.ts', () => ({
@@ -96,7 +96,7 @@ describe('Searcher Module', () => {
     it('should initialize search with correct event listeners on search button', () => {
       const searchButton = getSearchButton();
       const mockAddEventListener = vi.fn();
-      searchButton!.addEventListener = mockAddEventListener;
+      searchButton.addEventListener = mockAddEventListener;
 
       startupSearch();
 
@@ -113,11 +113,11 @@ describe('Searcher Module', () => {
       });
     });
 
-    it('should handle missing search toggle element gracefully', () => {
+    it('should throw when the search toggle element is missing', () => {
       const searchButton = getSearchButton();
-      searchButton?.remove();
+      searchButton.remove();
 
-      expect(() => startupSearch()).not.toThrow();
+      expect(() => startupSearch()).toThrow('Element not found: #search-btn');
     });
   });
 
@@ -142,7 +142,7 @@ describe('Searcher Module', () => {
       startupSearch();
 
       const searchButton = getSearchButton();
-      searchButton?.click();
+      searchButton.click();
 
       await vi.runAllTimersAsync();
 

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -99,7 +99,8 @@
     </div>
 
     <div popover id="search-pop">
-      <input type="search" id="searchbar" name="searchbar" placeholder="Search this book ..." role="combobox" aria-expanded="false" aria-controls="searchresults" aria-describedby="results-header">
+      <input type="search" id="searchbar" name="searchbar" placeholder="Search this book ..." role="combobox"
+        aria-label="Search this book" aria-expanded="false" aria-controls="searchresults" aria-describedby="results-header">
 
       <div id="results-header" aria-live="polite"></div>
       <ul id="searchresults" role="listbox"></ul>

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -98,8 +98,8 @@
       </aside>
     </div>
 
-    <div popover id="search-pop" role="dialog" aria-label="Search">
-      <input type="search" id="searchbar" name="searchbar" placeholder="Search this book ..." aria-controls="searchresults" aria-describedby="results-header">
+    <div popover id="search-pop">
+      <input type="search" id="searchbar" name="searchbar" placeholder="Search this book ..." role="combobox" aria-expanded="false" aria-controls="searchresults" aria-describedby="results-header">
 
       <div id="results-header" aria-live="polite"></div>
       <ul id="searchresults" role="listbox"></ul>


### PR DESCRIPTION
refs: #880 (and https://github.com/CoralPink/commentary/pull/878#pullrequestreview-4992508356)

As part of the fix for #880,
I added helpers to retrieve each element and reorganized the code, but the main purpose of this PR is to fix the `role` of the search popover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved search controls with clearer combobox semantics and expanded-state information.
  - Enhanced keyboard navigation: pressing Enter now focuses the first search result.

- **Bug Fixes**
  - Improved focus restoration and active-result tracking within search.
  - Search initialization now clearly reports missing required search controls instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->