### PR TITLE
feat(build): Use caching task results 🦕

### DIFF
--- a/js/deno.jsonc
+++ b/js/deno.jsonc
@@ -13,7 +13,23 @@
     ]
   },
   "tasks": {
-    "bundle": "rolldown -c",
+    "bundle": {
+      "command": "rolldown -c",
+      "files": [
+        "*.js",
+        "*.ts",
+        "*.d.ts",
+        "extensions/**/*.ts",
+        "types/**/*.ts",
+        "types/**/*.d.ts",
+        "utils/**/*.ts",
+        "webworker/**/*.ts",
+        "deno.jsonc",
+        "deno.lock",
+        "rolldown.config.mts"
+      ],
+      "output": ["dist/"]
+    },
     "serve": "deno run --allow-net --allow-read --allow-sys=networkInterfaces jsr:@std/http/file-server ../",
 
     "test": "vitest",

--- a/scss/deno.jsonc
+++ b/scss/deno.jsonc
@@ -6,6 +6,10 @@
     "sass": "npm:sass@1.103.1"
   },
   "tasks": {
-    "build": "deno run --allow-read --allow-write --allow-env --allow-ffi build.ts"
+    "build": {
+      "command": "deno run --allow-read --allow-write --allow-env --allow-ffi build.ts",
+      "files": ["src/**/*.scss", "build.ts", "deno.jsonc", "deno.lock", "rolldown.config.mts"],
+      "output": ["dist/"]
+    }
   }
 }


### PR DESCRIPTION
This PR leverages Deno's caching feature to optimize the build process.

refs: https://docs.deno.com/runtime/reference/cli/task/#caching-task-results

It seems to be working fine in my local environment,
but please give it a try to see if it works the same way on GitHub Actions!

> …The `deno` script that takes the longest to run in this project is `regenerate`,
> but since it isn't working properly yet, I'm putting it on hold for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved JavaScript and SCSS build tasks with explicit source file tracking.
  * Configured build outputs to be generated in the `dist/` directory.
  * Added support for automatically rebuilding when relevant source, configuration, declaration, or lock files change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->