### PR TITLE
Take the IME into account and handle `input` events appropriately 🧮

### DIFF
--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -4,7 +4,7 @@ import { SearchResults } from './searchResults.ts';
 
 import { loadStyleSheet } from './utils/css-loader.ts';
 import { fetchAndDecompress } from './utils/fetch.ts';
-import { debounce } from './utils/timing.ts';
+import { listenToInputEvents } from './utils/input.ts';
 import toast from './utils/toast.ts';
 
 // deno-lint-ignore no-sloppy-imports
@@ -12,8 +12,6 @@ import initWasm, { Finder } from './wasm_book.js';
 
 const FILE_STYLE_SEARCH = 'css/search.css';
 const FILE_INDEX = 'searchindex.json';
-
-const DEBOUNCE_DELAY_MS = 80;
 
 const LENGTH_FIELD_SIZE = 4; // 4byte: Uint32
 
@@ -71,10 +69,8 @@ const closedPopover = (ev: Event): void => {
   }
 };
 
-const debounceSearchInput = debounce((_: Event) => showResults(), DEBOUNCE_DELAY_MS);
-
-const searchbarKeydown = (ev: KeyboardEvent): void => {
-  if (ev.key !== 'ArrowDown') {
+const searchbarOnKeydown = (ev: KeyboardEvent): void => {
+  if (!(ev.key === 'ArrowDown' || ev.key === 'Enter')) {
     return;
   }
 
@@ -96,21 +92,12 @@ const showSearch = (): void => {
   elmSearchBar.select();
 
   searchAbort = new AbortController();
-  const signal = searchAbort.signal;
 
-  elmSearchBar.addEventListener('input', debounceSearchInput, {
-    passive: true,
-    signal,
-  });
-
-  elmSearchBar.addEventListener('keydown', searchbarKeydown, {
-    passive: false,
-    signal,
-  });
+  listenToInputEvents(elmSearchBar, searchAbort.signal, showResults, searchbarOnKeydown);
 
   elmPop.addEventListener('toggle', closedPopover, {
     passive: true,
-    signal,
+    signal: searchAbort.signal,
   });
 };
 

--- a/js/searcher.ts
+++ b/js/searcher.ts
@@ -75,6 +75,8 @@ const searchbarOnKeydown = (ev: KeyboardEvent): void => {
   }
 
   ev.preventDefault();
+
+  showResults();
   resultsList.focusFirstResult();
 };
 

--- a/js/serviceworker.ts
+++ b/js/serviceworker.ts
@@ -1,6 +1,6 @@
 declare const self: ServiceWorkerGlobalScope;
 
-const CACHE_VERSION = 'v11.13.1';
+const CACHE_VERSION = 'v11.13.2';
 
 const CACHE_URL = '/commentary/';
 const FALLBACK_IMAGE = 'favicon.png';

--- a/js/utils/input.ts
+++ b/js/utils/input.ts
@@ -82,17 +82,7 @@ export const listenToInputEvents = (
   element.addEventListener(
     "keydown",
     (ev: KeyboardEvent) => {
-      if (ev.isComposing) {
-        return;
-      }
-
-      if (skipComposedEnter && ev.key === "Enter") {
-        skipComposedEnter = false;
-        return;
-      }
-
-      skipComposedEnter = false;
-      onKeydown(ev);
+      if (ev.isComposing || skipComposedEnter) {
         skipComposedEnter = false;
         return;
       }

--- a/js/utils/input.ts
+++ b/js/utils/input.ts
@@ -1,0 +1,101 @@
+import { debounce } from "./timing.ts";
+
+const DEFAULT_DEBOUNCE_DELAY_MS = 80;
+
+/**
+ * Determine whether the current browser is Safari.
+ *
+ * This is intentionally a user-agent-based heuristic rather than feature
+ * detection. It is used only for a Safari-specific IME workaround, where
+ * Safari's composition and keyboard event ordering differs from other tested browsers.
+ */
+const isSafariBrowser = (): boolean => {
+  const ua = navigator.userAgent;
+  return /Version\/\d.*Safari\/\d/.test(ua) &&
+    !/Chrome|CriOS|Firefox|Brave/.test(ua);
+};
+
+/**
+ * Set up the Safari-specific IME workaround for an input element.
+ *
+ * Safari may dispatch `compositionend` before the `keydown` event for the Enter key that commits the composition.
+ * This makes `KeyboardEvent.isComposing` insufficient to distinguish that Enter from a normal Enter keydown.
+ *
+ * The workaround is intentionally limited to Safari because the event order
+ * observed in other tested browsers allows `KeyboardEvent.isComposing` to handle the composition-confirming Enter correctly.
+ *
+ * @param element The input element to listen to.
+ * @param signal The AbortSignal used to remove the event listener.
+ * @param onCompositionEnd Called when composition ends on Safari.
+ */
+const setupSafariImeWorkaround = (
+  element: HTMLInputElement,
+  signal: AbortSignal,
+  onCompositionEnd: () => void,
+): void => {
+  if (!isSafariBrowser()) {
+    return;
+  }
+
+  element.addEventListener("compositionend", onCompositionEnd, {
+    passive: true,
+    signal,
+  });
+};
+
+/**
+ * Listen for input and keyboard events on an input element.
+ *
+ * Input callbacks are debounced by the specified delay. Keyboard events are
+ * passed to the `onKeydown` callback unless the event is part of IME composition.
+ *
+ * A Safari-specific workaround is also installed to account for Safari's different composition and keyboard event ordering.
+ *
+ * The utility does not interpret keyboard keys itself; callers can decide
+ * which keys or keyboard actions they want to handle in `onKeydown`.
+ *
+ * @param element The input element to listen to.
+ * @param signal The AbortSignal used to remove the event listeners.
+ * @param onInput Called after an input event, debounced by `debounceDelayMs`.
+ * @param onKeydown Called for keyboard events outside of IME composition.
+ * @param debounceDelayMs The debounce delay in milliseconds. Defaults to `DEFAULT_DEBOUNCE_DELAY_MS`.
+ */
+export const listenToInputEvents = (
+  element: HTMLInputElement,
+  signal: AbortSignal,
+  onInput: () => void,
+  onKeydown: (ev: KeyboardEvent) => void,
+  debounceDelayMs: number = DEFAULT_DEBOUNCE_DELAY_MS,
+): void => {
+  let skipComposedEnter = false;
+
+  const debounceInput = debounce(
+    (_: InputEvent) => onInput(),
+    debounceDelayMs,
+  );
+
+  element.addEventListener("input", debounceInput, {
+    passive: true,
+    signal,
+  });
+
+  element.addEventListener(
+    "keydown",
+    (ev: KeyboardEvent) => {
+      if (ev.isComposing || skipComposedEnter) {
+        skipComposedEnter = false;
+        return;
+      }
+
+      onKeydown(ev);
+    },
+    {
+      passive: false,
+      signal,
+    },
+  );
+
+  setupSafariImeWorkaround(element, signal, () => {
+    skipComposedEnter = true;
+  });
+};

--- a/js/utils/input.ts
+++ b/js/utils/input.ts
@@ -1,4 +1,4 @@
-import { debounce } from "./timing.ts";
+import { debounce } from './timing.ts';
 
 const DEFAULT_DEBOUNCE_DELAY_MS = 80;
 
@@ -11,8 +11,7 @@ const DEFAULT_DEBOUNCE_DELAY_MS = 80;
  */
 const isSafariBrowser = (): boolean => {
   const ua = navigator.userAgent;
-  return /Version\/\d.*Safari\/\d/.test(ua) &&
-    !/Chrome|CriOS|Firefox|Brave/.test(ua);
+  return /Version\/\d.*Safari\/\d/.test(ua) && !/Chrome|CriOS|Firefox|Brave/.test(ua);
 };
 
 /**
@@ -37,7 +36,7 @@ const setupSafariImeWorkaround = (
     return;
   }
 
-  element.addEventListener("compositionend", onCompositionEnd, {
+  element.addEventListener('compositionend', onCompositionEnd, {
     passive: true,
     signal,
   });
@@ -69,18 +68,15 @@ export const listenToInputEvents = (
 ): void => {
   let skipComposedEnter = false;
 
-  const debounceInput = debounce(
-    (_: InputEvent) => onInput(),
-    debounceDelayMs,
-  );
+  const debounceInput = debounce((_: InputEvent) => onInput(), debounceDelayMs);
 
-  element.addEventListener("input", debounceInput, {
+  element.addEventListener('input', debounceInput, {
     passive: true,
     signal,
   });
 
   element.addEventListener(
-    "keydown",
+    'keydown',
     (ev: KeyboardEvent) => {
       if (ev.isComposing || skipComposedEnter) {
         skipComposedEnter = false;

--- a/js/utils/input.ts
+++ b/js/utils/input.ts
@@ -82,7 +82,17 @@ export const listenToInputEvents = (
   element.addEventListener(
     "keydown",
     (ev: KeyboardEvent) => {
-      if (ev.isComposing || skipComposedEnter) {
+      if (ev.isComposing) {
+        return;
+      }
+
+      if (skipComposedEnter && ev.key === "Enter") {
+        skipComposedEnter = false;
+        return;
+      }
+
+      skipComposedEnter = false;
+      onKeydown(ev);
         skipComposedEnter = false;
         return;
       }


### PR DESCRIPTION
This PR improves key focus handling for the search function.

Previously, when using an IME to enter text in the search bar, the `Enter` and `ArrowDown` keys were not handled correctly.

Since we have this opportunity, let’s extract the input functionality and include measures to address differences in behavior across browsers!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search input responsiveness and handling while typing.
  - Search interactions now work more reliably with keyboard input, including during text composition.
  - Pressing **Arrow Down** or **Enter** from the search bar now focuses the first result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->